### PR TITLE
boundary preprocessing

### DIFF
--- a/scripts/0_preprocess_inputs.py
+++ b/scripts/0_preprocess_inputs.py
@@ -1,0 +1,47 @@
+import geopandas as gpd
+
+import acbm
+from acbm.logger_config import preprocessing_logger_logger as logger
+from acbm.preprocessing import edit_boundary_resolution, filter_boundaries
+
+# ----- BOUNDARIES
+logger.info("Preprocessing Boundary Layer")
+
+## Read in the boundary layer for the whole of England
+
+logger.info("1. Reading in the boundary layer for the whole of England")
+
+
+boundaries = gpd.read_file(
+    acbm.root_path / "data/external/boundaries/oa_england.geojson"
+)
+
+boundaries = boundaries.to_crs(epsg=4326)
+
+## Dissolve boundaries if resolution is MSOA
+
+boundary_geography = "OA"  # can only be OA or MSOA
+logger.info(f"2. Dissolving boundaries to {boundary_geography} level")
+
+boundaries = edit_boundary_resolution(boundaries, boundary_geography)
+
+
+## Filter to study area
+
+logger.info("3. Filtering boundaries to specified study area")
+# TODO get from config and log
+# logger.info(f"3. Filtering boundaries to {config.parameters.boundary_filter_column} = {config.parameters.study_area}")
+
+boundaries_filtered = filter_boundaries(
+    boundaries=boundaries, column="LEP22NM1", values=["Leeds City Region"]
+)
+
+## Save the output as parquet
+logger.info(
+    f"4. Saving the boundaries to {acbm.root_path / 'data/external/boundaries/'} path"
+)
+
+boundaries_filtered.to_file(
+    acbm.root_path / "data/external/boundaries/study_area_zones.geojson",
+    driver="GeoJSON",
+)

--- a/scripts/3.1_assign_primary_feasible_zones.py
+++ b/scripts/3.1_assign_primary_feasible_zones.py
@@ -37,15 +37,10 @@ def main(config_file):
     # --- Study area boundaries
 
     logger.info("Loading study area boundaries")
-    where_clause = "MSOA21NM LIKE '%Leeds%'"
 
     boundaries = gpd.read_file(
-        acbm.root_path / "data/external/boundaries/oa_england.geojson",
-        where=where_clause,
+        acbm.root_path / "data/external/boundaries/study_area_zones.geojson"
     )
-
-    # convert boundaries to 4326
-    boundaries = boundaries.to_crs(epsg=4326)
 
     logger.info("Study area boundaries loaded")
 

--- a/scripts/3.2.2_assign_primary_zone_work.py
+++ b/scripts/3.2.2_assign_primary_zone_work.py
@@ -35,14 +35,13 @@ def main(config_file):
 
     # --- boundaries
 
-    where_clause = "MSOA21NM LIKE '%Leeds%'"
+    logger.info("Loading study area boundaries")
 
     boundaries = gpd.read_file(
-        acbm.root_path / "data/external/boundaries/oa_england.geojson",
-        where=where_clause,
+        acbm.root_path / "data/external/boundaries/study_area_zones.geojson"
     )
 
-    boundaries = boundaries.to_crs(epsg=4326)
+    logger.info("Study area boundaries loaded")
 
     # osm POI data
 

--- a/scripts/3.2.3_assign_secondary_zone.py
+++ b/scripts/3.2.3_assign_secondary_zone.py
@@ -45,15 +45,11 @@ def main(config_file):
 
     logger.info("Preprocessing: Adding OA21CD to the data")
 
-    where_clause = "MSOA21NM LIKE '%Leeds%'"
-
     boundaries = gpd.read_file(
-        acbm.root_path / "data/external/boundaries/oa_england.geojson",
-        where=where_clause,
+        acbm.root_path / "data/external/boundaries/study_area_zones.geojson"
     )
 
-    # convert boundaries to 4326
-    boundaries = boundaries.to_crs(epsg=4326)
+    logger.info("Study area boundaries loaded")
 
     # --- Assign activity home locations to boundaries zoning system
 

--- a/scripts/3.3_assign_facility_all.py
+++ b/scripts/3.3_assign_facility_all.py
@@ -49,15 +49,13 @@ def main(config_file):
     )
 
     # --- Load data: Boundaries
-    logger.info("Loading boundaries data")
-
-    where_clause = "MSOA21NM LIKE '%Leeds%'"
+    logger.info("Loading study area boundaries")
 
     boundaries = gpd.read_file(
-        acbm.root_path / "data/external/boundaries/oa_england.geojson",
-        where=where_clause,
+        acbm.root_path / "data/external/boundaries/study_area_zones.geojson"
     )
-    boundaries = boundaries.to_crs(epsg=4326)
+
+    logger.info("Study area boundaries loaded")
 
     # --- Prepprocess: add zone column to POI data
     logger.info("Adding zone column to POI data")

--- a/src/acbm/logger_config.py
+++ b/src/acbm/logger_config.py
@@ -40,6 +40,7 @@ def create_logger(name, log_file):
 
 
 # Create loggers for different modules
+preprocessing_logger = create_logger("preprocessing", "preprocessing.log")
 matching_logger = create_logger("matching", "matching.log")
 assigning_primary_feasible_logger = create_logger(
     "assigning_primary_feasible", "assigning_primary_feasible.log"


### PR DESCRIPTION
This PR should allow users to prepare the boundary layer for the study area of choice. 

- It replaces hardcoded filtering to Leeds. 
- It allows us to use OAs or MSOAs for the analysis. It assumes that we have an OA layer for the whole of England (which we can provide as part of the pipeline). We cannot use a custom zoning system with the current logic

TODO before merging:

- [ ] Move [boundaries_geography](https://github.com/Urban-Analytics-Technology-Platform/acbm/blob/eb1801fc2636c19f7b5ef3759b6750071c7fdc3b/scripts/0_preprocess_inputs.py#L23) to config
- [ ] Move [filter_boundaries arguments](https://github.com/Urban-Analytics-Technology-Platform/acbm/blob/eb1801fc2636c19f7b5ef3759b6750071c7fdc3b/scripts/0_preprocess_inputs.py#L35) to config
- [ ] Clarify in the config that travel_times shuld only be true if we have a travel time matrix at the resolution specified by boundary_geography (i.e. if we choose boundary_geography == "MSOA" and travel_times = True but our travel times matrix is at the OA level, the code will not work)

