### PR TITLE
Fix workzone assignment

### DIFF
--- a/config/base.toml
+++ b/config/base.toml
@@ -1,12 +1,29 @@
 [parameters]
 seed = 0
-region = "leeds"
-number_of_households = 5000
-zone_id = "OA21CD"
-travel_times = true         # Only set to true if you have travel time matrix at the level specified in boundary_geography
+region = "leeds"  # this is used to query poi data from osm and to load in SPC data
+number_of_households = 5000  # how many people from the SPC do we want to run the model for? Comment out if you want to run the analysis on the entire SPC populaiton
+zone_id = "OA21CD" # "OA21CD": OA level, "MSOA11CD": MSOA level
+travel_times = true  # Only set to true if you have travel time matrix at the level specified in boundary_geography
 boundary_geography = "OA"
+# NTS years to use
+nts_years = [2019, 2021, 2022]
+# NTS regions to use
+nts_regions = [
+    'Yorkshire and the Humber',
+    'North West',
+    'North East',
+    'East Midlands',
+    'West Midlands',
+    'East of England',
+    'South East',
+    'South West']
+# nts day of the week to use
+# 1: Monday, 2: Tuesday, 3: Wednesday, 4: Thursday, 5: Friday, 6: Saturday, 7: Sunday
+nts_day_of_week = 3
 
 [matching]
+# for optional and required columns, see the [iterative_match_categorical](https://github.com/Urban-Analytics-Technology-Platform/acbm/blob/ca181c54d7484ebe44706ff4b43c26286b22aceb/src/acbm/matching.py#L110) function
+# Do not add any column not listed below. You can only move a column from optional to require (or vise versa)
 required_columns = ["number_adults", "number_children"]
 optional_columns = [
     "number_cars",
@@ -15,10 +32,12 @@ optional_columns = [
     "employment_status",
     "tenure_status",
 ]
-n_matches = 10
+n_matches = 10 # What is the maximum number of NTS matches we want for each SPC household?
 
 [work_assignment]
-use_percentages = true
+commute_level = "MSOA"
+use_percentages = true  # if true, optimization problem will try to minimize percentage difference at OD level (not absolute numbers). Recommended to set it to true
+# weights to add for each objective in the optimization problem
 weight_max_dev = 0.2
 weight_total_dev = 0.8
-max_zones = 8
+max_zones = 8   # maximum number of feasible zones to include in the optimization problem (less zones makes problem smaller - so faster, but at the cost of a better solution)

--- a/notebooks/2_match_households_and_individuals.ipynb
+++ b/notebooks/2_match_households_and_individuals.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
     "from acbm.matching import MatcherExact, match_individuals\n",
     "from acbm.preprocessing import (\n",
     "    count_per_group,\n",
-    "    #nts_filter_by_region,\n",
+    "    nts_filter_by_region,\n",
     "    nts_filter_by_year,\n",
     "    num_adult_child_hh,\n",
     "    transform_by_group,\n",
@@ -470,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -539,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,16 +635,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
-    "years = [2019, 2021, 2022]\n",
+    "years = [2018, 2019, 2021, 2022]\n",
     "\n",
     "nts_individuals = nts_filter_by_year(nts_individuals, psu, years)\n",
     "nts_households = nts_filter_by_year(nts_households, psu, years)\n",
     "nts_trips = nts_filter_by_year(nts_trips, psu, years)\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of rows in individuals: 52351\n",
+      "Number of rows in households: 22545\n",
+      "Number of rows in trips: 630600\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get number of rows in each table\n",
+    "print(f\"Number of rows in individuals: {nts_individuals.shape[0]}\")\n",
+    "print(f\"Number of rows in households: {nts_households.shape[0]}\")\n",
+    "print(f\"Number of rows in trips: {nts_trips.shape[0]}\")"
    ]
   },
   {
@@ -658,15 +680,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[0;31mSignature:\u001b[0m\n",
+      "\u001b[0mnts_filter_by_region\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mdata\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mpandas\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mframe\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataFrame\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mpsu\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mpandas\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mframe\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataFrame\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mregions\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mpandas\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mframe\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataFrame\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mDocstring:\u001b[0m\n",
+      "Filter the NTS dataframe based on the chosen region(s)\n",
+      "\n",
+      "data: pandas DataFrame\n",
+      "    The NTS data to be filtered\n",
+      "psu: pandas DataFrame\n",
+      "    The Primary Sampling Unit table in the NTS. It has the region assigned to each sample\n",
+      "regions: list\n",
+      "    The chosen region(s)\n",
+      "\u001b[0;31mFile:\u001b[0m      ~/Documents/GitHub/acbm/src/acbm/preprocessing.py\n",
+      "\u001b[0;31mType:\u001b[0m      function"
+     ]
+    }
+   ],
+   "source": [
+    "?nts_filter_by_region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# regions = ['Yorkshire and the Humber', 'North West']\n",
+    "# Keep all regions except for London (as it is very different from the rest of the country)\n",
+    "regions = [\n",
+    "    'Yorkshire and the Humber', \n",
+    "    'North West',\n",
+    "    'North East',\n",
+    "    'East Midlands',\n",
+    "    'West Midlands',\n",
+    "    'East of England',\n",
+    "    'South East',\n",
+    "    'South West']\n",
     "\n",
-    "# nts_individuals = nts_filter_by_region(nts_individuals, psu, regions)\n",
-    "# nts_households = nts_filter_by_region(nts_households, psu, regions)\n",
-    "# nts_trips = nts_filter_by_region(nts_trips, psu, regions)\n"
+    "nts_individuals = nts_filter_by_region(nts_individuals, psu, regions)\n",
+    "nts_households = nts_filter_by_region(nts_households, psu, regions)\n",
+    "nts_trips = nts_filter_by_region(nts_trips, psu, regions)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of rows in individuals: 27003\n",
+      "Number of rows in households: 11581\n",
+      "Number of rows in trips: 369196\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get number of rows in each table\n",
+    "print(f\"Number of rows in individuals: {nts_individuals.shape[0]}\")\n",
+    "print(f\"Number of rows in households: {nts_households.shape[0]}\")\n",
+    "print(f\"Number of rows in trips: {nts_trips.shape[0]}\")"
    ]
   },
   {

--- a/scripts/2_match_households_and_individuals.py
+++ b/scripts/2_match_households_and_individuals.py
@@ -15,7 +15,7 @@ from acbm.logger_config import matching_logger as logger
 from acbm.matching import MatcherExact, match_individuals
 from acbm.preprocessing import (
     count_per_group,
-    # nts_filter_by_region,
+    nts_filter_by_region,
     nts_filter_by_year,
     num_adult_child_hh,
     transform_by_group,
@@ -244,7 +244,7 @@ def main(config_file):
 
     logger.info("Filtering NTS data by specified year(s)")
 
-    years = [2019, 2021, 2022]
+    years = config.parameters.nts_years
 
     nts_individuals = nts_filter_by_year(nts_individuals, psu, years)
     nts_households = nts_filter_by_year(nts_households, psu, years)
@@ -252,14 +252,12 @@ def main(config_file):
 
     # #### Filter by geography
     #
-    # I will not do this for categorical matching, as it reduces the sample significantly,
-    # and leads to more spc households not being matched
 
-    # regions = ['Yorkshire and the Humber', 'North West']
+    regions = config.parameters.nts_regions
 
-    # nts_individuals = nts_filter_by_region(nts_individuals, psu, regions)
-    # nts_households = nts_filter_by_region(nts_households, psu, regions)
-    # nts_trips = nts_filter_by_region(nts_trips, psu, regions)
+    nts_individuals = nts_filter_by_region(nts_individuals, psu, regions)
+    nts_households = nts_filter_by_region(nts_households, psu, regions)
+    nts_trips = nts_filter_by_region(nts_trips, psu, regions)
 
     # Create dictionaries of key value pairs
 

--- a/scripts/3.1_assign_primary_feasible_zones.py
+++ b/scripts/3.1_assign_primary_feasible_zones.py
@@ -96,7 +96,9 @@ def main(config_file):
         # If travel_times is not true or loading failed, create a new travel time matrix
         logger.info("No travel time matrix found. Creating a new travel time matrix.")
         # Create a new travel time matrix based on distances between zones
-        travel_times = zones_to_time_matrix(zones=boundaries, id_col=config.zone_id)
+        travel_times = zones_to_time_matrix(
+            zones=boundaries, id_col=config.zone_id, time_units="m"
+        )
         logger.info("Travel time estimates created")
         # save travel_times as parquet
 

--- a/scripts/3.1_assign_primary_feasible_zones.py
+++ b/scripts/3.1_assign_primary_feasible_zones.py
@@ -32,7 +32,9 @@ def main(config_file):
 
     # Filter to a specific day of the week
     logger.info("Filtering activity chains to a specific day of the week")
-    activity_chains = activity_chains[activity_chains["TravDay"] == 3]  # Wednesday
+    activity_chains = activity_chains[
+        activity_chains["TravDay"] == config.parameters.nts_day_of_week
+    ]  # Wednesday
 
     # --- Study area boundaries
 

--- a/scripts/3.2.1_assign_primary_zone_edu.py
+++ b/scripts/3.2.1_assign_primary_zone_edu.py
@@ -56,7 +56,9 @@ def main(config_file):
     logger.info("Loading activity chains")
 
     activity_chains = activity_chains_for_assignment(columns=cols_for_assignment_edu())
-    activity_chains = activity_chains[activity_chains["TravDay"] == 3]  # Wednesday
+    activity_chains = activity_chains[
+        activity_chains["TravDay"] == config.parameters.nts_day_of_week
+    ]  # Wednesday
 
     logger.info("Filtering activity chains for trip purpose: education")
     activity_chains_edu = activity_chains[activity_chains["dact"] == "education"]

--- a/scripts/3.2.2_assign_primary_zone_work.py
+++ b/scripts/3.2.2_assign_primary_zone_work.py
@@ -54,7 +54,9 @@ def main(config_file):
     # --- Activity chains
     activity_chains = activity_chains_for_assignment(cols_for_assignment_work())
     activity_chains = add_locations_to_activity_chains(activity_chains)
-    activity_chains = activity_chains[activity_chains["TravDay"] == 3]  # Wednesday
+    activity_chains = activity_chains[
+        activity_chains["TravDay"] == config.parameters.nts_day_of_week
+    ]  # Wednesday
 
     activity_chains_work = activity_chains[activity_chains["dact"] == "work"]
 

--- a/scripts/3.2.3_assign_secondary_zone.py
+++ b/scripts/3.2.3_assign_secondary_zone.py
@@ -39,7 +39,9 @@ def main(config_file):
     logger.info("Loading: activity chains")
 
     activity_chains = activity_chains_for_assignment()
-    activity_chains = activity_chains[activity_chains["TravDay"] == 3]  # Wednesday
+    activity_chains = activity_chains[
+        activity_chains["TravDay"] == config.parameters.nts_day_of_week
+    ]  # Wednesday
 
     # --- Add OA21CD to the data
 

--- a/scripts/4_validation.py
+++ b/scripts/4_validation.py
@@ -5,6 +5,8 @@ import pandas as pd
 import seaborn as sns
 
 import acbm
+from acbm.cli import acbm_cli
+from acbm.config import load_config
 from acbm.logger_config import validation_logger as logger
 from acbm.validating.plots import (
     plot_activity_sequence_comparison,
@@ -13,263 +15,265 @@ from acbm.validating.plots import (
 )
 from acbm.validating.utils import calculate_od_distances, process_sequences
 
-# ----- Folder for validation plots
 
-logger.info("1. Creating folder for validation plots")
+@acbm_cli
+def main(config_file):
+    config = load_config(config_file)
+    config.init_rng()
 
-validation_plots_path = acbm.root_path / "data/processed/plots/validation"
-os.makedirs(validation_plots_path, exist_ok=True)
+    # ----- Folder for validation plots
+
+    logger.info("1. Creating folder for validation plots")
+
+    validation_plots_path = acbm.root_path / "data/processed/plots/validation"
+    os.makedirs(validation_plots_path, exist_ok=True)
+
+    # ----- Reading in the data
+
+    logger.info("2. Reading in the data")
+
+    # NTS data
+    legs_nts = pd.read_parquet(
+        acbm.root_path / "data/external/nts/filtered/nts_trips.parquet"
+    )
+
+    legs_nts = legs_nts[legs_nts["TravDay"] == config.parameters.nts_day_of_week]
+
+    # Model outputs
+    legs_acbm = pd.read_csv(acbm.root_path / "data/processed/activities_pam/legs.csv")
+    legs_acbm_geo = pd.read_parquet(
+        acbm.root_path / "data/processed/activities_pam/legs_with_locations.parquet"
+    )
+
+    # ----- Preproccessing the data
+
+    logger.info("3a. Preprocessing: renaming columns")
+
+    # rename origin activity and destination activity columns
+    legs_acbm = legs_acbm.rename(
+        columns={"origin activity": "oact", "destination activity": "dact"}
+    )
+    legs_acbm_geo = legs_acbm_geo.rename(
+        columns={"origin activity": "oact", "destination activity": "dact"}
+    )
+
+    # rename distance column in NTS
+    legs_nts = legs_nts.rename(columns={"TripDisIncSW": "distance"})
+
+    logger.info("3b. Preprocessing: Edit distance column in NTS")
+
+    # convert legs_nts["distance"] from miles to km
+    legs_nts["distance"] = legs_nts["distance"] * 1.60934
+
+    logger.info("3c. Preprocessing: Adding hour of day column")
+
+    # acbm - tst is in datetime format
+    # Convert tst to datetime format and extract the hour component in one step
+    legs_acbm["tst_hour"] = legs_acbm["tst"].apply(lambda x: pd.to_datetime(x).hour)
+    legs_acbm["tet_hour"] = legs_acbm["tet"].apply(lambda x: pd.to_datetime(x).hour)
+
+    # nts - tst is in minutes
+    # Convert legs_nts["tst"] from minutes to hours
+    legs_nts["tst_hour"] = legs_nts["tst"] // 60
+    legs_nts["tet_hour"] = legs_nts["tet"] // 60
+
+    logger.info("3d. Preprocessing: Abbreviating column values for trip purpose")
+
+    # Mapping dictionary
+    activity_mapping = {
+        "home": "h",
+        "other": "o",
+        "escort": "e",
+        "work": "w",
+        "shop": "sh",
+        "visit": "v",
+        "education": "edu",
+        "medical": "m",
+    }
+
+    legs_acbm["oact_abr"] = legs_acbm["oact"].replace(activity_mapping)
+    legs_acbm["dact_abr"] = legs_acbm["dact"].replace(activity_mapping)
+
+    legs_nts["oact_abr"] = legs_nts["oact"].replace(activity_mapping)
+    legs_nts["dact_abr"] = legs_nts["dact"].replace(activity_mapping)
+
+    # ----- Validation Plots
+
+    logger.info("4. Validation plots")
+
+    logger.info("4a.1 Validation (Matching) - Trip Purpose")
+
+    # Get number of trips by mode for legs_nts, and legs_acbm, and plot a comparative bar plot
+    # NTS
+    purpose_nts = legs_nts.groupby("dact").size().reset_index(name="count")
+    purpose_nts["source"] = "nts"
+
+    # ACBM
+    purpose_acbm = legs_acbm.groupby("dact").size().reset_index(name="count")
+    purpose_acbm["source"] = "acbm"
+
+    # Combine the data
+    purpose_compare = pd.concat([purpose_nts, purpose_acbm])
+
+    # Calculate the percentage of trips for each mode within each source
+    purpose_compare["percentage"] = purpose_compare.groupby("source")[
+        "count"
+    ].transform(lambda x: (x / x.sum()) * 100)
+
+    sns.barplot(data=purpose_compare, x="dact", y="percentage", hue="source")
+    plt.xlabel("Trip purpose")
+    plt.ylabel("Percentage of total trips")
+    plt.title("Percentage of Trips by Purpose for NTS and ACBM")
+    # plt.show()
+
+    # Save the plot
+    plt.tight_layout()
+    plt.savefig(validation_plots_path / "1_matching_trip_purpose.png")
+
+    logger.info("4a.2 Validation (Matching) - Trip Mode")
+
+    # Get number of trips by mode for legs_nts, and legs_acbm, and plot a comparative bar plot
+    # NTS
+    modeshare_nts = legs_nts.groupby("mode").size().reset_index(name="count")
+    modeshare_nts["source"] = "nts"
+
+    # ACBM
+    modeshare_acbm = legs_acbm.groupby("mode").size().reset_index(name="count")
+    modeshare_acbm["source"] = "acbm"
+
+    # Combine the data
+    modeshare_compare = pd.concat([modeshare_nts, modeshare_acbm])
+    # Calculate the percentage of trips for each mode within each source
+    modeshare_compare["percentage"] = modeshare_compare.groupby("source")[
+        "count"
+    ].transform(lambda x: (x / x.sum()) * 100)
+
+    # Plot
+    sns.barplot(data=modeshare_compare, x="mode", y="percentage", hue="source")
+    plt.ylabel("Percentage of total trips")
+    plt.title("Percentage of Trips by Mode for NTS and ACBM")
+    # plt.show()
+
+    # Save the plot
+    plt.tight_layout()
+    plt.savefig(validation_plots_path / "2_matching_trip_mode.png")
+
+    logger.info("4a.3 Validation (Matching) - time of day")
+
+    # Plot aggregate
+    plot_comparison(
+        legs_acbm,
+        legs_nts,
+        value_column="tst_hour",
+        max_y_value=20,
+        plot_type="time",
+        figsize=(10, 5),
+        plot_mode="aggregate",
+        save_path=validation_plots_path / "3a_matching_time_of_day_aggregate.png",
+    )
+
+    # Plot facet
+    plot_comparison(
+        legs_acbm,
+        legs_nts,
+        value_column="tst_hour",
+        max_y_value=70,
+        plot_type="time",
+        plot_mode="facet",
+        save_path=validation_plots_path / "3b_matching_time_of_day_facet.png",
+    )
+
+    logger.info("4a.4 Validation (Matching) - Activity Sequences")
+
+    # Process the sequences for ACBM and NTS data
+
+    sequence_nts = process_sequences(
+        df=legs_nts,
+        pid_col="IndividualID",
+        seq_col="seq",
+        origin_activity_col="oact_abr",
+        destination_activity_col="dact_abr",
+        suffix="nts",
+    )
+
+    sequence_acbm = process_sequences(
+        df=legs_acbm,
+        pid_col="pid",
+        seq_col="seq",
+        origin_activity_col="oact_abr",
+        destination_activity_col="dact_abr",
+        suffix="acbm",
+    )
+
+    # Plot the comparison
+
+    plot_activity_sequence_comparison(
+        sequence_nts=sequence_nts,
+        sequence_acbm=sequence_acbm,
+        activity_mapping=activity_mapping,
+        perc_cutoff=0.35,
+        save_path=validation_plots_path / "4_matching_activity_sequences.png",
+    )
+
+    logger.info("4b. Validation (Assigning) - Trip Distance")
+
+    # Apply the function to legs_acbm_geo
+    legs_acbm_geo = calculate_od_distances(
+        df=legs_acbm_geo,
+        start_wkt_col="start_location_geometry_wkt",
+        end_wkt_col="end_location_geometry_wkt",
+    )
+
+    # Plot: Aggregate
+    plot_comparison(
+        legs_acbm_geo,
+        legs_nts,
+        value_column="distance",
+        bin_size=2,
+        value_threshold=50,
+        max_y_value=30,
+        figsize=(10, 5),
+        plot_type="distance",
+        plot_mode="aggregate",
+        save_path=validation_plots_path / "5a_assigning_distance_aggregate.png",
+    )
+
+    # Plot: Facet by activity_type
+    plot_comparison(
+        legs_acbm_geo,
+        legs_nts,
+        value_column="distance",
+        bin_size=2,
+        value_threshold=50,
+        max_y_value=30,
+        plot_type="distance",
+        plot_mode="facet",
+        save_path=validation_plots_path / "5b_assigning_distance_facet.png",
+    )
+
+    logger.info("4c.1 Validation (Assigning) - Intrazonal Activities")
+
+    # -- Plot: by trip purpose
+    # Calculate the percentage of intrazonal trips for each unique purpose
+
+    plot_intrazonal_trips(
+        legs_acbm,
+        validation_plots_path=validation_plots_path,
+        plot_type="purp",
+        plot_name="6a_assigning_intrazonal_purp.png",
+    )
+
+    # -- Plot: By OD pair
+    # Calculate the percentage of intrazonal trips for each unique OD combination
+    # (e.g. home - work)
+
+    plot_intrazonal_trips(
+        legs_acbm,
+        validation_plots_path=validation_plots_path,
+        plot_type="od",
+        plot_name="6b_assigning_intrazonal_od.png",
+    )
 
 
-# ----- Reading in the data
-
-logger.info("2. Reading in the data")
-
-# NTS data
-legs_nts = pd.read_parquet(
-    acbm.root_path / "data/external/nts/filtered/nts_trips.parquet"
-)
-
-legs_nts = legs_nts[legs_nts["TravDay"] == 3]
-
-# Model outputs
-legs_acbm = pd.read_csv(acbm.root_path / "data/processed/activities_pam/legs.csv")
-legs_acbm_geo = pd.read_parquet(
-    acbm.root_path / "data/processed/activities_pam/legs_with_locations.parquet"
-)
-
-# ----- Preproccessing the data
-
-logger.info("3a. Preprocessing: renaming columns")
-
-# rename origin activity and destination activity columns
-legs_acbm = legs_acbm.rename(
-    columns={"origin activity": "oact", "destination activity": "dact"}
-)
-legs_acbm_geo = legs_acbm_geo.rename(
-    columns={"origin activity": "oact", "destination activity": "dact"}
-)
-
-# rename distance column in NTS
-legs_nts = legs_nts.rename(columns={"TripDisIncSW": "distance"})
-
-logger.info("3b. Preprocessing: Edit distance column in NTS")
-
-# convert legs_nts["distance"] from miles to km
-legs_nts["distance"] = legs_nts["distance"] * 1.60934
-
-logger.info("3c. Preprocessing: Adding hour of day column")
-
-# acbm - tst is in datetime format
-# Convert tst to datetime format and extract the hour component in one step
-legs_acbm["tst_hour"] = legs_acbm["tst"].apply(lambda x: pd.to_datetime(x).hour)
-legs_acbm["tet_hour"] = legs_acbm["tet"].apply(lambda x: pd.to_datetime(x).hour)
-
-# nts - tst is in minutes
-# Convert legs_nts["tst"] from minutes to hours
-legs_nts["tst_hour"] = legs_nts["tst"] // 60
-legs_nts["tet_hour"] = legs_nts["tet"] // 60
-
-
-logger.info("3d. Preprocessing: Abbreviating column values for trip purpose")
-
-# Mapping dictionary
-activity_mapping = {
-    "home": "h",
-    "other": "o",
-    "escort": "e",
-    "work": "w",
-    "shop": "sh",
-    "visit": "v",
-    "education": "edu",
-    "medical": "m",
-}
-
-legs_acbm["oact_abr"] = legs_acbm["oact"].replace(activity_mapping)
-legs_acbm["dact_abr"] = legs_acbm["dact"].replace(activity_mapping)
-
-legs_nts["oact_abr"] = legs_nts["oact"].replace(activity_mapping)
-legs_nts["dact_abr"] = legs_nts["dact"].replace(activity_mapping)
-
-
-# ----- Validation Plots
-
-logger.info("4. Validation plots")
-
-logger.info("4a.1 Validation (Matching) - Trip Purpose")
-
-# Get number of trips by mode for legs_nts, and legs_acbm, and plot a comparative bar plot
-# NTS
-purpose_nts = legs_nts.groupby("dact").size().reset_index(name="count")
-purpose_nts["source"] = "nts"
-
-# ACBM
-purpose_acbm = legs_acbm.groupby("dact").size().reset_index(name="count")
-purpose_acbm["source"] = "acbm"
-
-# Combine the data
-purpose_compare = pd.concat([purpose_nts, purpose_acbm])
-
-# Calculate the percentage of trips for each mode within each source
-purpose_compare["percentage"] = purpose_compare.groupby("source")["count"].transform(
-    lambda x: (x / x.sum()) * 100
-)
-
-
-sns.barplot(data=purpose_compare, x="dact", y="percentage", hue="source")
-plt.xlabel("Trip purpose")
-plt.ylabel("Percentage of total trips")
-plt.title("Percentage of Trips by Purpose for NTS and ACBM")
-# plt.show()
-
-# Save the plot
-plt.tight_layout()
-plt.savefig(validation_plots_path / "1_matching_trip_purpose.png")
-
-logger.info("4a.2 Validation (Matching) - Trip Mode")
-
-# Get number of trips by mode for legs_nts, and legs_acbm, and plot a comparative bar plot
-# NTS
-modeshare_nts = legs_nts.groupby("mode").size().reset_index(name="count")
-modeshare_nts["source"] = "nts"
-
-# ACBM
-modeshare_acbm = legs_acbm.groupby("mode").size().reset_index(name="count")
-modeshare_acbm["source"] = "acbm"
-
-# Combine the data
-modeshare_compare = pd.concat([modeshare_nts, modeshare_acbm])
-# Calculate the percentage of trips for each mode within each source
-modeshare_compare["percentage"] = modeshare_compare.groupby("source")[
-    "count"
-].transform(lambda x: (x / x.sum()) * 100)
-
-# Plot
-sns.barplot(data=modeshare_compare, x="mode", y="percentage", hue="source")
-plt.ylabel("Percentage of total trips")
-plt.title("Percentage of Trips by Mode for NTS and ACBM")
-# plt.show()
-
-# Save the plot
-plt.tight_layout()
-plt.savefig(validation_plots_path / "2_matching_trip_mode.png")
-
-logger.info("4a.3 Validation (Matching) - time of day")
-
-# Plot aggregate
-plot_comparison(
-    legs_acbm,
-    legs_nts,
-    value_column="tst_hour",
-    max_y_value=20,
-    plot_type="time",
-    figsize=(10, 5),
-    plot_mode="aggregate",
-    save_path=validation_plots_path / "3a_matching_time_of_day_aggregate.png",
-)
-
-# Plot facet
-plot_comparison(
-    legs_acbm,
-    legs_nts,
-    value_column="tst_hour",
-    max_y_value=70,
-    plot_type="time",
-    plot_mode="facet",
-    save_path=validation_plots_path / "3b_matching_time_of_day_facet.png",
-)
-
-
-logger.info("4a.4 Validation (Matching) - Activity Sequences")
-
-# Process the sequences for ACBM and NTS data
-
-sequence_nts = process_sequences(
-    df=legs_nts,
-    pid_col="IndividualID",
-    seq_col="seq",
-    origin_activity_col="oact_abr",
-    destination_activity_col="dact_abr",
-    suffix="nts",
-)
-
-sequence_acbm = process_sequences(
-    df=legs_acbm,
-    pid_col="pid",
-    seq_col="seq",
-    origin_activity_col="oact_abr",
-    destination_activity_col="dact_abr",
-    suffix="acbm",
-)
-
-
-# Plot the comparison
-
-plot_activity_sequence_comparison(
-    sequence_nts=sequence_nts,
-    sequence_acbm=sequence_acbm,
-    activity_mapping=activity_mapping,
-    perc_cutoff=0.35,
-    save_path=validation_plots_path / "4_matching_activity_sequences.png",
-)
-
-logger.info("4b. Validation (Assigning) - Trip Distance")
-
-# Apply the function to legs_acbm_geo
-legs_acbm_geo = calculate_od_distances(
-    df=legs_acbm_geo,
-    start_wkt_col="start_location_geometry_wkt",
-    end_wkt_col="end_location_geometry_wkt",
-)
-
-
-# Plot: Aggregate
-plot_comparison(
-    legs_acbm_geo,
-    legs_nts,
-    value_column="distance",
-    bin_size=2,
-    value_threshold=50,
-    max_y_value=30,
-    figsize=(10, 5),
-    plot_type="distance",
-    plot_mode="aggregate",
-    save_path=validation_plots_path / "5a_assigning_distance_aggregate.png",
-)
-
-# Plot: Facet by activity_type
-plot_comparison(
-    legs_acbm_geo,
-    legs_nts,
-    value_column="distance",
-    bin_size=2,
-    value_threshold=50,
-    max_y_value=30,
-    plot_type="distance",
-    plot_mode="facet",
-    save_path=validation_plots_path / "5b_assigning_distance_facet.png",
-)
-
-
-logger.info("4c.1 Validation (Assigning) - Intrazonal Activities")
-
-# -- Plot: by trip purpose
-# Calculate the percentage of intrazonal trips for each unique purpose
-
-plot_intrazonal_trips(
-    legs_acbm,
-    validation_plots_path=validation_plots_path,
-    plot_type="purp",
-    plot_name="6a_assigning_intrazonal_purp.png",
-)
-
-# -- Plot: By OD pair
-# Calculate the percentage of intrazonal trips for each unique OD combination
-# (e.g. home - work)
-
-plot_intrazonal_trips(
-    legs_acbm,
-    validation_plots_path=validation_plots_path,
-    plot_type="od",
-    plot_name="6b_assigning_intrazonal_od.png",
-)
+if __name__ == "__main__":
+    main()

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -11,3 +11,5 @@ python scripts/3.2.1_assign_primary_zone_edu.py --config_file $1
 python scripts/3.2.2_assign_primary_zone_work.py --config_file $1
 python scripts/3.2.3_assign_secondary_zone.py --config_file $1
 python scripts/3.3_assign_facility_all.py --config_file $1
+python scripts/4_validation.py --config_file $1
+python scripts/5_acbm_to_matsim_xml.py --config_file $1

--- a/src/acbm/assigning/feasible_zones_primary.py
+++ b/src/acbm/assigning/feasible_zones_primary.py
@@ -134,7 +134,9 @@ def get_possible_zones(
 
     if travel_times is None:
         logger.info("Travel time matrix not provided: Creating travel times estimates")
-        travel_times = zones_to_time_matrix(zones=boundaries, id_col=zone_id)
+        travel_times = zones_to_time_matrix(
+            zones=boundaries, id_col=zone_id, time_units="m"
+        )
 
     list_of_modes = activity_chains["mode"].unique()
     print(f"Unique modes found in the dataset are: {list_of_modes}")

--- a/src/acbm/assigning/plots.py
+++ b/src/acbm/assigning/plots.py
@@ -200,7 +200,7 @@ def plot_workzone_assignment_heatmap(
         )
 
         ax = sns.heatmap(
-            heatmap_data, cmap="RdBu", ax=axes[i], cbar=i == len(categories) - 1
+            heatmap_data, cmap="viridis", ax=axes[i], cbar=i == len(categories) - 1
         )
         axes[i].set_title(f"Demand Difference: % of {category} Total")
         axes[i].set_xlabel("Home Zone")

--- a/src/acbm/assigning/select_zone_work.py
+++ b/src/acbm/assigning/select_zone_work.py
@@ -488,16 +488,13 @@ class WorkZoneAssignment:
                 for person_id, origins in self.activities_to_assign.items()
                 if (person_id, from_zone, to_zone) in assignment_vars
             )
-            # Calculate the assigned percentage based on the total flows to each destination zone
-            if to_zone in self.total_flows:
-                total_people = self.total_flows[to_zone]
+            # Calculate the assigned percentage based on the total flows from each origin zone
+            if from_zone in self.total_flows:
+                total_people = self.total_flows[from_zone]
                 assigned_percentage = assigned_flow / total_people
-            # If the origin zone is not in the total flows, set the assigned percentage to 0
             else:
                 assigned_percentage = 0
-                logger.warning(
-                    f"Warning: Destination {to_zone} not found in total_flows."
-                )
+                logger.warning(f"Warning: Origin {from_zone} not found in total_flows.")
 
             if use_percentages:
                 # to satisfy both constraints, abs_dev will be a positive number (it is the larger of the two)

--- a/src/acbm/assigning/utils.py
+++ b/src/acbm/assigning/utils.py
@@ -287,6 +287,7 @@ def _get_activities_per_zone_df(activities_per_zone: dict) -> pd.DataFrame:
 def zones_to_time_matrix(
     zones: gpd.GeoDataFrame,
     id_col: Optional[str] = None,
+    time_units: str = "s",
 ) -> pd.DataFrame:
     """
     Calculates the distance matrix between the centroids of the given zones and returns it as a DataFrame. The matrix also adds
@@ -302,7 +303,8 @@ def zones_to_time_matrix(
         A GeoDataFrame containing the zones.
     id_col: str, optional
         The name of the column in the zones GeoDataFrame to use as the ID. If None, the index values are used. Default is None.
-
+    time_units: str, optional
+        The units to use for the travel time. Options are 's' for seconds and 'm' for minutes. Default is 's'.
     Returns
     -------
     pd.DataFrame
@@ -346,6 +348,10 @@ def zones_to_time_matrix(
         mode_data["mode"] = mode
         mode_data["time"] = mode_data["distance"] / speed
         long_format_data.append(mode_data)
+
+        # Convert time to the desired units
+        if time_units == "m":
+            mode_data["time"] = mode_data["time"] / 60  # Convert seconds to minutes
 
     # Concatenate the list into a single DataFrame
     return pd.concat(long_format_data, ignore_index=True)

--- a/src/acbm/config.py
+++ b/src/acbm/config.py
@@ -15,6 +15,9 @@ class Parameters(BaseModel):
     zone_id: str
     travel_times: bool
     boundary_geography: str
+    nts_years: list[int]
+    nts_regions: list[str]
+    nts_day_of_week: int
 
 
 @dataclass(frozen=True)
@@ -31,7 +34,7 @@ class WorkAssignmentParams(BaseModel):
     weight_max_dev: float
     weight_total_dev: float
     max_zones: int
-    commute_level: str | None
+    commute_level: str | None = None
 
 
 class Config(BaseModel):


### PR DESCRIPTION
This PR fixes a bug in workzone assignment, specifically in this commit https://github.com/Urban-Analytics-Technology-Platform/acbm/commit/596d2f809ff5780dfcc624f28b24ea16853a1d56

- zones_to_time_matrix was returning time estimates in seconds instead of minutes (see [here](https://github.com/Urban-Analytics-Technology-Platform/acbm/blob/135744b04b4698c70a9587f9eae05649faa8b761/src/acbm/assigning/utils.py#L287)). This was causing problems downstream as get_possible_zones compres reported NTS travel time (which is in **minutes**), to our time estimates, so our feasible_zones for each activity was only returning the origin zone. I have edited zones_to_time_matrix to return time in minutes

- select_workzone_optimisation was umming flows incorrectly. Actual flows were summed at the origin, while assigned_flows were summed at the destination, so the deviation calculation was not making sense. I have fixed that