### PR TITLE
Revise travel day and region variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ The pipeline is a series of scripts that are run in sequence to generate the act
 │   │   │   └── Output_Areas_Dec_2011_PWC_2022.csv
 │   │   ├── MSOA_2011_MSOA_2021_Lookup_for_England_and_Wales.csv
 │   │   ├── nts
-│   │   │   ├── filtered
-│   │   │   │   ├── nts_households.parquet
-│   │   │   │   ├── nts_individuals.parquet
-│   │   │   │   └── nts_trips.parquet
 │   │   │   └── UKDA-5340-tab
 │   │   │       ├── 5340_file_information.rtf
 │   │   │       ├── mrdoc
@@ -120,6 +116,9 @@ The pipeline is a series of scripts that are run in sequence to generate the act
 │           ├── plots
 │           │   ├── assigning
 │           │   └── validation
+│           ├── nts_households.parquet
+│           ├── nts_individuals.parquet
+│           └── nts_trips.parquet
 ```
 
 ## Step 1: Prepare Data Inputs

--- a/config/base.toml
+++ b/config/base.toml
@@ -20,7 +20,7 @@ nts_regions = [
 ]
 # nts day of the week to use
 # 1: Monday, 2: Tuesday, 3: Wednesday, 4: Thursday, 5: Friday, 6: Saturday, 7: Sunday
-nts_day_of_week = 3
+nts_days_of_week = [3]
 # what crs do we want the output to be in? (just add the number, e.g. 3857)
 output_crs = 3857
 

--- a/config/base.toml
+++ b/config/base.toml
@@ -9,14 +9,19 @@ boundary_geography = "OA"
 nts_years = [2019, 2021, 2022]
 # NTS regions to use
 nts_regions = [
-    'Yorkshire and the Humber',
-    'North West',
-    'North East',
-    'East Midlands',
-    'West Midlands',
-    'East of England',
-    'South East',
-    'South West',
+    "Northern, Metropolitan",
+    # "Northern, Non-metropolitan",
+    "Yorkshire / Humberside, Metropolitan",
+    # "Yorkshire / Humberside, Non-metropolitan",
+    "East Midlands",
+    "East Anglia",
+    "South East (excluding London Boroughs)",
+    # "London Boroughs",
+    "South West",
+    "West Midlands, Metropolitan",
+    # "West Midlands, Non-metropolitan",
+    "North West, Metropolitan",
+    # "North West, Non-metropolitan",
 ]
 # nts day of the week to use
 # 1: Monday, 2: Tuesday, 3: Wednesday, 4: Thursday, 5: Friday, 6: Saturday, 7: Sunday

--- a/config/base.toml
+++ b/config/base.toml
@@ -4,10 +4,10 @@ region = "leeds"            # this is used to query poi data from osm and to loa
 number_of_households = 5000 # how many people from the SPC do we want to run the model for? Comment out if you want to run the analysis on the entire SPC populaiton
 zone_id = "OA21CD"          # "OA21CD": OA level, "MSOA11CD": MSOA level
 travel_times = true         # Only set to true if you have travel time matrix at the level specified in boundary_geography
-boundary_geography = "OA"
+boundary_geography = "OA"   # boundary geography to use for the analysis
 # NTS years to use
 nts_years = [2019, 2021, 2022]
-# NTS regions to use
+# NTS regions to use: the values here correspond categories for "PSUStatsReg_B01ID" in the NTS
 nts_regions = [
     "Northern, Metropolitan",
     # "Northern, Non-metropolitan",
@@ -23,15 +23,34 @@ nts_regions = [
     "North West, Metropolitan",
     # "North West, Non-metropolitan",
 ]
-# nts day of the week to use
+# nts days of the week to use
 # 1: Monday, 2: Tuesday, 3: Wednesday, 4: Thursday, 5: Friday, 6: Saturday, 7: Sunday
 nts_days_of_week = [3]
 # what crs do we want the output to be in? (just add the number, e.g. 3857)
 output_crs = 3857
+# tolerance_work: the proportion difference allowed for determining feasible zones for work
+tolerance_work = 0.3
+# tolerance_edu: the proportion difference allowed for determining feasible zones for education
+tolerance_edu = 0.3
+# common_household_day:
+# - true: whether to only have households where all individuals have at least one day of the week in
+#         common for travel.
+# - false: households are kept only where all individuals have a travel day in NTS days of the week
+common_household_day = true
+# part_time_work_prob: this float scales the commuting flows since the census question is about
+# main place of work and on a given day there is an average probability that a person is not at
+# this main place of work. This assumes `use_percentages = false` in the [work_assignment] section
+# and has no effect otherwise.
+# See: https://github.com/Urban-Analytics-Technology-Platform/acbm/pull/90#issue-2823864300
+# TODO: consider renaming this parameter and moving it to the [work_assignment] section
+#       see: https://github.com/Urban-Analytics-Technology-Platform/acbm/issues/99
+part_time_work_prob = 0.7
+n_processes = 6 # number of processes to use for parallel processing, excluded from serialization
 
 [matching]
 # for optional and required columns, see the [iterative_match_categorical](https://github.com/Urban-Analytics-Technology-Platform/acbm/blob/ca181c54d7484ebe44706ff4b43c26286b22aceb/src/acbm/matching.py#L110) function
-# Do not add any column not listed below. You can only move a column from optional to require (or vise versa)
+# Do not add any column not listed below. You can only move a column from optional to require (or
+# vise versa)
 required_columns = ["number_adults", "number_children"]
 optional_columns = [
     "number_cars",
@@ -57,11 +76,16 @@ decay_rate = 0.0001
 
 [work_assignment]
 commute_level = "OA"
-use_percentages = true # if true, optimization problem will try to minimize percentage difference at OD level (not absolute numbers). Recommended to set it to true
-# weights to add for each objective in the optimization problem
+# if true, optimization problem will try to minimize percentage difference at OD level (not absolute
+# numbers). Recommended to set it to true.
+use_percentages = true
+# weight for max deviation over all commuting flows for combined objective
 weight_max_dev = 0.2
+# weight for total deviation over all commuting flows for combined objective
 weight_total_dev = 0.8
-max_zones = 8          # maximum number of feasible zones to include in the optimization problem (less zones makes problem smaller - so faster, but at the cost of a better solution)
+# maximum number of feasible zones to include in the optimization problem (less zones makes problem
+# smaller - so faster, but at the cost of a better solution)
+max_zones = 8
 
 [postprocessing]
 pam_jitter = 30

--- a/scripts/2_match_households_and_individuals.py
+++ b/scripts/2_match_households_and_individuals.py
@@ -16,6 +16,7 @@ from acbm.preprocessing import (
     transform_by_group,
     truncate_values,
 )
+from acbm.utils import households_with_common_travel_days
 
 
 @acbm_cli
@@ -237,8 +238,18 @@ def main(config_file):
     nts_households = nts_filter_by_region(nts_households, psu, regions)
     nts_trips = nts_filter_by_region(nts_trips, psu, regions)
 
-    # Create dictionaries of key value pairs
+    # Ensure that the households have at least one day in `nts_days_of_week` that
+    # all household members have trips for
+    hids = households_with_common_travel_days(
+        nts_trips, config.parameters.nts_days_of_week
+    )
 
+    # Subset individuals and households given filtering of trips
+    nts_trips = nts_trips[nts_trips["HouseholdID"].isin(hids)]
+    nts_individuals = nts_individuals[nts_individuals["HouseholdID"].isin(hids)]
+    nts_households = nts_households[nts_households["HouseholdID"].isin(hids)]
+
+    # Create dictionaries of key value pairs
     """
     guide to the dictionaries:
 

--- a/scripts/2_match_households_and_individuals.py
+++ b/scripts/2_match_households_and_individuals.py
@@ -16,7 +16,10 @@ from acbm.preprocessing import (
     transform_by_group,
     truncate_values,
 )
-from acbm.utils import households_with_common_travel_days
+from acbm.utils import (
+    households_with_common_travel_days,
+    households_with_travel_days_in_nts_weeks,
+)
 
 
 @acbm_cli
@@ -241,9 +244,14 @@ def main(config_file):
 
     # Ensure that the households have at least one day in `nts_days_of_week` that
     # all household members have trips for
-    hids = households_with_common_travel_days(
-        nts_trips, config.parameters.nts_days_of_week
-    )
+    if config.parameters.common_household_day:
+        hids = households_with_common_travel_days(
+            nts_trips, config.parameters.nts_days_of_week
+        )
+    else:
+        hids = households_with_travel_days_in_nts_weeks(
+            nts_trips, config.parameters.nts_days_of_week
+        )
 
     # Subset individuals and households given filtering of trips
     nts_trips = nts_trips[

--- a/scripts/2_match_households_and_individuals.py
+++ b/scripts/2_match_households_and_individuals.py
@@ -245,7 +245,10 @@ def main(config_file):
     )
 
     # Subset individuals and households given filtering of trips
-    nts_trips = nts_trips[nts_trips["HouseholdID"].isin(hids)]
+    nts_trips = nts_trips[
+        nts_trips["HouseholdID"].isin(hids)
+        & nts_trips["TravDay"].isin(config.parameters.nts_days_of_week)
+    ]
     nts_individuals = nts_individuals[nts_individuals["HouseholdID"].isin(hids)]
     nts_households = nts_households[nts_households["HouseholdID"].isin(hids)]
 

--- a/scripts/2_match_households_and_individuals.py
+++ b/scripts/2_match_households_and_individuals.py
@@ -7,7 +7,7 @@ import pandas as pd
 from acbm.assigning.utils import cols_for_assignment_all
 from acbm.cli import acbm_cli
 from acbm.config import load_and_setup_config
-from acbm.matching import MatcherExact, match_individuals
+from acbm.matching import MatcherExact, match_individuals, match_remaining_individuals
 from acbm.preprocessing import (
     count_per_group,
     nts_filter_by_region,
@@ -952,6 +952,19 @@ def main(config_file):
             matches_hh=matches_hh_level_sample,
             show_progress=True,
         )
+
+        # match remaining individuals
+        remaining_ids = spc_edited.loc[
+            ~spc_edited.index.isin(matches_ind.keys()), "id"
+        ].to_list()
+        matches_remaining_ind = match_remaining_individuals(
+            df1=spc_edited,
+            df2=nts_individuals,
+            matching_columns=["age_group", "sex"],
+            remaining_ids=remaining_ids,
+            show_progress=True,
+        )
+        matches_ind.update(matches_remaining_ind)
 
         # save random sample
         with open(

--- a/scripts/2_match_households_and_individuals.py
+++ b/scripts/2_match_households_and_individuals.py
@@ -234,6 +234,7 @@ def main(config_file):
 
     regions = config.parameters.nts_regions
 
+    # TODO: Currently this only seems to work for 2019, check this
     nts_individuals = nts_filter_by_region(nts_individuals, psu, regions)
     nts_households = nts_filter_by_region(nts_households, psu, regions)
     nts_trips = nts_filter_by_region(nts_trips, psu, regions)

--- a/scripts/2_match_households_and_individuals.py
+++ b/scripts/2_match_households_and_individuals.py
@@ -226,21 +226,27 @@ def main(config_file):
 
     logger.info("Filtering NTS data by specified year(s)")
 
+    logger.info(f"Total NTS households: {nts_households.shape[0]:,.0f}")
     years = config.parameters.nts_years
 
     nts_individuals = nts_filter_by_year(nts_individuals, psu, years)
     nts_households = nts_filter_by_year(nts_households, psu, years)
     nts_trips = nts_filter_by_year(nts_trips, psu, years)
 
+    logger.info(
+        f"Total NTS households (after year filtering): {nts_households.shape[0]:,.0f}"
+    )
     # #### Filter by geography
-    #
 
     regions = config.parameters.nts_regions
 
-    # TODO: Currently this only seems to work for 2019, check this
     nts_individuals = nts_filter_by_region(nts_individuals, psu, regions)
     nts_households = nts_filter_by_region(nts_households, psu, regions)
     nts_trips = nts_filter_by_region(nts_trips, psu, regions)
+
+    logger.info(
+        f"Total NTS households (after region filtering): {nts_households.shape[0]:,.0f}"
+    )
 
     # Ensure that the households have at least one day in `nts_days_of_week` that
     # all household members have trips for

--- a/scripts/3.1_assign_primary_feasible_zones.py
+++ b/scripts/3.1_assign_primary_feasible_zones.py
@@ -31,7 +31,7 @@ def main(config_file):
     # Filter to a specific day of the week
     logger.info("Filtering activity chains to a specific day of the week")
     activity_chains = activity_chains[
-        activity_chains["TravDay"] == config.parameters.nts_day_of_week
+        activity_chains["TravDay"].isin(config.parameters.nts_days_of_week)
     ]
 
     # --- Study area boundaries

--- a/scripts/3.1_assign_primary_feasible_zones.py
+++ b/scripts/3.1_assign_primary_feasible_zones.py
@@ -32,7 +32,7 @@ def main(config_file):
     logger.info("Filtering activity chains to a specific day of the week")
 
     # Generate random sample of days by household
-    get_chosen_day(config).to_parquet(
+    get_chosen_day(activity_chains, config.parameters.common_household_day).to_parquet(
         config.output_path / "interim" / "assigning" / "chosen_trav_day.parquet"
     )
 

--- a/scripts/3.1_assign_primary_feasible_zones.py
+++ b/scripts/3.1_assign_primary_feasible_zones.py
@@ -1,13 +1,13 @@
 import pickle as pkl
 
 import geopandas as gpd
-import numpy as np
 import pandas as pd
 
 from acbm.assigning.feasible_zones_primary import get_possible_zones
 from acbm.assigning.utils import (
     activity_chains_for_assignment,
     get_activities_per_zone,
+    get_chosen_day,
     intrazone_time,
     replace_intrazonal_travel_time,
     zones_to_time_matrix,
@@ -32,15 +32,7 @@ def main(config_file):
     logger.info("Filtering activity chains to a specific day of the week")
 
     # Generate random sample of days by household
-    activity_chains.merge(
-        activity_chains.groupby(["household"])["TravDay"]
-        .apply(np.unique)
-        .apply(np.random.choice)
-        .rename("ChosenTravDay"),
-        left_on=["household", "TravDay"],
-        right_on=["household", "ChosenTravDay"],
-        how="inner",
-    )[["id", "household", "TravDay"]].drop_duplicates().to_parquet(
+    get_chosen_day(config).to_parquet(
         config.output_path / "interim" / "assigning" / "chosen_trav_day.parquet"
     )
 

--- a/scripts/3.2.1_assign_primary_zone_edu.py
+++ b/scripts/3.2.1_assign_primary_zone_edu.py
@@ -51,11 +51,8 @@ def main(config_file):
     logger.info("Loading activity chains")
 
     activity_chains = activity_chains_for_assignment(
-        config, columns=cols_for_assignment_edu()
+        config, columns=cols_for_assignment_edu(), subset_to_chosen_day=True
     )
-    activity_chains = activity_chains[
-        activity_chains["TravDay"].isin(config.parameters.nts_days_of_week)
-    ]
 
     logger.info("Filtering activity chains for trip purpose: education")
     activity_chains_edu = activity_chains[activity_chains["dact"] == "education"]

--- a/scripts/3.2.1_assign_primary_zone_edu.py
+++ b/scripts/3.2.1_assign_primary_zone_edu.py
@@ -54,7 +54,7 @@ def main(config_file):
         config, columns=cols_for_assignment_edu()
     )
     activity_chains = activity_chains[
-        activity_chains["TravDay"] == config.parameters.nts_day_of_week
+        activity_chains["TravDay"].isin(config.parameters.nts_days_of_week)
     ]
 
     logger.info("Filtering activity chains for trip purpose: education")

--- a/scripts/3.2.2_assign_primary_zone_work.py
+++ b/scripts/3.2.2_assign_primary_zone_work.py
@@ -98,7 +98,7 @@ def main(config_file):
 
         logger.info("Step 4: Filtering rows and dropping unnecessary columns")
         travel_demand_clipped = travel_demand[
-            travel_demand["Place of work indicator (4 categories) code"].isin([1, 3])
+            travel_demand["Place of work indicator (4 categories) code"].isin([3])
         ]
         travel_demand_clipped = travel_demand_clipped.drop(
             columns=[
@@ -139,7 +139,7 @@ def main(config_file):
 
         logger.info("Step 2: Filtering rows and dropping unnecessary columns")
         travel_demand_clipped = travel_demand[
-            travel_demand["Place of work indicator (4 categories) code"].isin([1, 3])
+            travel_demand["Place of work indicator (4 categories) code"].isin([3])
         ]
         travel_demand_clipped = travel_demand_clipped.drop(
             columns=[

--- a/scripts/3.2.2_assign_primary_zone_work.py
+++ b/scripts/3.2.2_assign_primary_zone_work.py
@@ -45,7 +45,7 @@ def main(config_file):
 
     activity_chains = activity_chains_for_assignment(config, cols_for_assignment_work())
     activity_chains = activity_chains[
-        activity_chains["TravDay"] == config.parameters.nts_day_of_week
+        activity_chains["TravDay"].isin(config.parameters.nts_days_of_week)
     ]
 
     logger.info("Filtering activity chains for trip purpose: work")

--- a/scripts/3.2.2_assign_primary_zone_work.py
+++ b/scripts/3.2.2_assign_primary_zone_work.py
@@ -42,11 +42,9 @@ def main(config_file):
 
     # --- Activity chains
     logger.info("Loading activity chains")
-
-    activity_chains = activity_chains_for_assignment(config, cols_for_assignment_work())
-    activity_chains = activity_chains[
-        activity_chains["TravDay"].isin(config.parameters.nts_days_of_week)
-    ]
+    activity_chains = activity_chains_for_assignment(
+        config, cols_for_assignment_work(), subset_to_chosen_day=True
+    )
 
     logger.info("Filtering activity chains for trip purpose: work")
     activity_chains_work = activity_chains[activity_chains["dact"] == "work"]

--- a/scripts/3.2.2_assign_primary_zone_work.py
+++ b/scripts/3.2.2_assign_primary_zone_work.py
@@ -200,7 +200,9 @@ def main(config_file):
     #### ASSIGN TO ZONE FROM FEASIBLE ZONES ####
 
     zone_assignment = WorkZoneAssignment(
-        activities_to_assign=possible_zones_work, actual_flows=travel_demand_dict_nomode
+        activities_to_assign=possible_zones_work,
+        actual_flows=travel_demand_dict_nomode,
+        scaling=config.parameters.part_time_work_prob,
     )
 
     assignments_df = zone_assignment.select_work_zone_optimization(

--- a/scripts/3.2.3_assign_secondary_zone.py
+++ b/scripts/3.2.3_assign_secondary_zone.py
@@ -40,7 +40,7 @@ def main(config_file):
 
     activity_chains = activity_chains_for_assignment(config)
     activity_chains = activity_chains[
-        activity_chains["TravDay"] == config.parameters.nts_day_of_week
+        activity_chains["TravDay"].isin(config.parameters.nts_days_of_week)
     ]
 
     # TODO: remove obsolete comment

--- a/scripts/3.2.3_assign_secondary_zone.py
+++ b/scripts/3.2.3_assign_secondary_zone.py
@@ -38,10 +38,7 @@ def main(config_file):
     # --- Load in the data
     logger.info("Loading: activity chains")
 
-    activity_chains = activity_chains_for_assignment(config)
-    activity_chains = activity_chains[
-        activity_chains["TravDay"].isin(config.parameters.nts_days_of_week)
-    ]
+    activity_chains = activity_chains_for_assignment(config, subset_to_chosen_day=True)
 
     # TODO: remove obsolete comment
     # --- Add OA21CD to the data

--- a/scripts/3.3_assign_facility_all.py
+++ b/scripts/3.3_assign_facility_all.py
@@ -91,6 +91,7 @@ def main(config_file):
         gdf_facility_type_col="activities",
         gdf_sample_col="floor_area",
         neighboring_zones=zone_neighbors,
+        n_processes=config.parameters.n_processes,
     )
 
     # Map the activity_id and activity_geometry to the activity_chains_home_df DataFrame
@@ -113,6 +114,7 @@ def main(config_file):
         gdf_facility_type_col="activities",
         gdf_sample_col="floor_area",
         neighboring_zones=zone_neighbors,
+        n_processes=config.parameters.n_processes,
     )
 
     # Map the activity_id and activity_geometry to the activity_chains_df DataFrame
@@ -156,6 +158,7 @@ def main(config_file):
         gdf_sample_col="floor_area",
         neighboring_zones=zone_neighbors,
         fallback_type="education",
+        n_processes=config.parameters.n_processes,
     )
 
     logger.info(f"Shape of activity chains edu: {activity_chains_edu.shape}")
@@ -196,6 +199,7 @@ def main(config_file):
         gdf_sample_col="floor_area",
         neighboring_zones=zone_neighbors,
         fallback_to_random=True,
+        n_processes=config.parameters.n_processes,
     )
 
     # Map the activity_id and activity_geometry to the activity_chains_home_df DataFrame

--- a/scripts/4_validation.py
+++ b/scripts/4_validation.py
@@ -29,7 +29,7 @@ def main(config_file):
     # NTS data
     legs_nts = pd.read_parquet(config.output_path / "nts_trips.parquet")
 
-    legs_nts = legs_nts[legs_nts["TravDay"] == config.parameters.nts_day_of_week]
+    legs_nts = legs_nts[legs_nts["TravDay"].isin(config.parameters.nts_days_of_week)]
 
     # Model outputs
     legs_acbm = pd.read_csv(config.output_path / "legs.csv")

--- a/scripts/4_validation.py
+++ b/scripts/4_validation.py
@@ -59,8 +59,8 @@ def main(config_file):
 
     # acbm - tst is in datetime format
     # Convert tst to datetime format and extract the hour component in one step
-    legs_acbm["tst_hour"] = legs_acbm["tst"].apply(lambda x: pd.to_datetime(x).hour)
-    legs_acbm["tet_hour"] = legs_acbm["tet"].apply(lambda x: pd.to_datetime(x).hour)
+    legs_acbm["tst_hour"] = pd.to_datetime(legs_acbm["tst"]).dt.hour
+    legs_acbm["tet_hour"] = pd.to_datetime(legs_acbm["tet"]).dt.hour
 
     # nts - tst is in minutes
     # Convert legs_nts["tst"] from minutes to hours

--- a/scripts/4_validation.py
+++ b/scripts/4_validation.py
@@ -183,8 +183,7 @@ def main(config_file):
 
     sequence_nts = process_sequences(
         df=legs_nts,
-        pid_col="IndividualID",
-        seq_col="seq",
+        groupby_cols=["IndividualID", "DayID"],
         origin_activity_col="oact_abr",
         destination_activity_col="dact_abr",
         suffix="nts",
@@ -192,8 +191,7 @@ def main(config_file):
 
     sequence_acbm = process_sequences(
         df=legs_acbm,
-        pid_col="pid",
-        seq_col="seq",
+        groupby_cols=["pid"],
         origin_activity_col="oact_abr",
         destination_activity_col="dact_abr",
         suffix="acbm",

--- a/src/acbm/assigning/feasible_zones_primary.py
+++ b/src/acbm/assigning/feasible_zones_primary.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("assigning_primary_feasible")
 activity_chains_schema = DataFrameSchema(
     {
         "mode": Column(str),
-        "TravDay": Column(pa.Float, Check.isin([1, 2, 3, 4, 5, 6, 7]), nullable=True),
+        # "TravDay": Column(pa.Float, Check.isin([1, 2, 3, 4, 5, 6, 7]), nullable=True),
         "tst": Column(pa.Float, Check.less_than_or_equal_to(1440), nullable=True),
         "TripTotalTime": Column(pa.Float, nullable=True),
         # TODO: add more columns ...

--- a/src/acbm/assigning/feasible_zones_primary.py
+++ b/src/acbm/assigning/feasible_zones_primary.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("assigning_primary_feasible")
 activity_chains_schema = DataFrameSchema(
     {
         "mode": Column(str),
-        # "TravDay": Column(pa.Float, Check.isin([1, 2, 3, 4, 5, 6, 7]), nullable=True),
+        "TravDay": Column(pa.Float, Check.isin([1, 2, 3, 4, 5, 6, 7]), nullable=True),
         "tst": Column(pa.Float, Check.less_than_or_equal_to(1440), nullable=True),
         "TripTotalTime": Column(pa.Float, nullable=True),
         # TODO: add more columns ...

--- a/src/acbm/assigning/select_facility.py
+++ b/src/acbm/assigning/select_facility.py
@@ -174,6 +174,7 @@ def select_facility(
     neighboring_zones: Optional[dict] = None,
     fallback_type: Optional[str] = None,
     fallback_to_random: bool = False,
+    n_processes: int = max(int(cpu_count() * 0.75), 1),
 ) -> dict[str, Tuple[str, Point] | Tuple[float, float]]:
     """
     Select facilities for each row in the DataFrame based on the provided logic.
@@ -205,8 +206,7 @@ def select_facility(
         keys with selected facility ID and facility ID's geometry, or (np.nan, np.nan)
     """
     # TODO: check if this is deterministic for a given seed (or pass seed to pool)
-    # TODO: update to be configurable
-    with Pool(max(int(cpu_count() * 0.75), 1)) as p:
+    with Pool(n_processes) as p:
         # Set to a large enough chunk size so that each process
         # has a sufficiently large amount of processing to do.
         chunk_size = 16_000

--- a/src/acbm/assigning/select_facility.py
+++ b/src/acbm/assigning/select_facility.py
@@ -1,5 +1,5 @@
 import logging
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 from typing import Optional, Tuple
 
 import geopandas as gpd
@@ -204,9 +204,9 @@ def select_facility(
     dict[str, Tuple[str, Point ] | Tuple[float, float]]: Unique ID column as
         keys with selected facility ID and facility ID's geometry, or (np.nan, np.nan)
     """
-    # TODO: update this to be configurable, `None` is os.process_cpu_count()
     # TODO: check if this is deterministic for a given seed (or pass seed to pool)
-    with Pool(None) as p:
+    # TODO: update to be configurable
+    with Pool(max(int(cpu_count() * 0.75), 1)) as p:
         # Set to a large enough chunk size so that each process
         # has a sufficiently large amount of processing to do.
         chunk_size = 16_000

--- a/src/acbm/assigning/select_zone_work.py
+++ b/src/acbm/assigning/select_zone_work.py
@@ -51,6 +51,7 @@ class WorkZoneAssignment:
     remaining_flows: Dict[Tuple[str, str], int] = field(init=False)
     total_flows: Dict[str, int] = field(init=False)
     percentages: Dict[Tuple[str, str], float] = field(init=False)
+    scaling: float = field(init=True)
 
     def __post_init__(self):
         """
@@ -75,9 +76,9 @@ class WorkZoneAssignment:
         total_flows = {}
         for (from_zone, _), flow in self.actual_flows.items():
             if from_zone in total_flows:
-                total_flows[from_zone] += flow
+                total_flows[from_zone] += int(flow * self.scaling)
             else:
-                total_flows[from_zone] = flow
+                total_flows[from_zone] = int(flow * self.scaling)
         return total_flows
 
     def _calculate_percentages(self) -> Dict[Tuple[str, str], float]:

--- a/src/acbm/assigning/utils.py
+++ b/src/acbm/assigning/utils.py
@@ -61,7 +61,7 @@ def activity_chains_for_assignment(
         pd.read_parquet(
             config.output_path / "interim" / "assigning" / "chosen_trav_day.parquet"
         ),
-        on=["id", "household", "TravDay"],
+        on=["id", "TravDay"],
         how="inner",
     )
 

--- a/src/acbm/assigning/utils.py
+++ b/src/acbm/assigning/utils.py
@@ -18,6 +18,7 @@ def cols_for_assignment_all() -> list[str]:
         "age_years",
         "TripDisIncSW",
         "tet",
+        "DayID",
     ]
 
 

--- a/src/acbm/assigning/utils.py
+++ b/src/acbm/assigning/utils.py
@@ -11,7 +11,6 @@ def cols_for_assignment_all() -> list[str]:
     """Gets activity chains with subset of columns required for assignment."""
     return [
         *cols_for_assignment_edu(),
-        "household",
         "oact",
         "nts_ind_id",
         "nts_hh_id",
@@ -25,12 +24,13 @@ def cols_for_assignment_all() -> list[str]:
 def cols_for_assignment_edu() -> list[str]:
     """Gets activity chains with subset of columns required for assignment."""
     return [
+        "id",
+        "household",
         "TravDay",
         "OA11CD",
         "dact",
         "mode",
         "tst",
-        "id",
         "seq",
         "TripTotalTime",
         "education_type",
@@ -43,15 +43,25 @@ def cols_for_assignment_work() -> list[str]:
 
 
 def activity_chains_for_assignment(
-    config: Config, columns: list[str] | None = None
+    config: Config, columns: list[str] | None = None, subset_to_chosen_day: bool = False
 ) -> pd.DataFrame:
     """Gets activity chains with subset of columns required for assignment."""
     if columns is None:
         columns = cols_for_assignment_all()
 
-    return pd.read_parquet(
+    activity_chains = pd.read_parquet(
         config.spc_with_nts_trips_filepath,
         columns=columns,
+    )
+    if not subset_to_chosen_day:
+        return activity_chains
+
+    return activity_chains.merge(
+        pd.read_parquet(
+            config.output_path / "interim" / "assigning" / "chosen_trav_day.parquet"
+        ),
+        on=["id", "household", "TravDay"],
+        how="inner",
     )
 
 

--- a/src/acbm/config.py
+++ b/src/acbm/config.py
@@ -41,7 +41,30 @@ class Parameters(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
+    @field_validator("nts_regions")
+    def validate_nts_regions(nts_regions: list[str]) -> list[str]:
+        # "PSUStatsReg_B01ID" regions
+        B01ID_REGIONS = [
+            "Northern, Metropolitan",
+            "Northern, Non-metropolitan",
+            "Yorkshire / Humberside, Metropolitan",
+            "Yorkshire / Humberside, Non-metropolitan",
+            "East Midlands",
+            "East Anglia",
+            "South East (excluding London Boroughs)",
+            "London Boroughs",
+            "South West",
+            "West Midlands, Metropolitan",
+            "West Midlands, Non-metropolitan",
+            "North West, Metropolitan",
+            "North West, Non-metropolitan",
+        ]
 
+        for region in nts_regions:
+            if region not in B01ID_REGIONS:
+                msg = f"Region ('{region}') is not in valid regions: {B01ID_REGIONS}"
+                raise ValueError(msg)
+        return nts_regions
 
     @field_validator("output_crs")
     def validate_output_crs(output_crs: int) -> int:

--- a/src/acbm/config.py
+++ b/src/acbm/config.py
@@ -27,7 +27,7 @@ class Parameters(BaseModel):
     boundary_geography: str
     nts_years: list[int]
     nts_regions: list[str]
-    nts_day_of_week: int
+    nts_days_of_week: list[int]
     output_crs: int
     tolerance_work: float | None = None
     tolerance_edu: float | None = None

--- a/src/acbm/config.py
+++ b/src/acbm/config.py
@@ -9,6 +9,7 @@ from typing import Tuple
 import geopandas as gpd
 import jcs
 import numpy as np
+import polars as pl
 import tomlkit
 from pydantic import BaseModel, Field, field_serializer, field_validator
 from pyproj import CRS
@@ -31,6 +32,8 @@ class Parameters(BaseModel):
     output_crs: int
     tolerance_work: float | None = None
     tolerance_edu: float | None = None
+    common_household_day: bool = False
+    part_time_work_prob: float = 0.7
 
     @field_validator("output_crs")
     def validate_output_crs(output_crs: int) -> int:
@@ -371,6 +374,8 @@ class Config(BaseModel):
         try:
             np.random.seed(self.seed)
             random.seed(self.seed)
+            pl.set_random_seed(self.seed)
+
         except Exception as err:
             msg = f"config does not provide a rng seed with err: {err}"
             raise ValueError(msg) from err

--- a/src/acbm/config.py
+++ b/src/acbm/config.py
@@ -32,7 +32,7 @@ class Parameters(BaseModel):
     output_crs: int
     tolerance_work: float | None = None
     tolerance_edu: float | None = None
-    common_household_day: bool = False
+    common_household_day: bool = True
     part_time_work_prob: float = 0.7
 
     @field_validator("output_crs")

--- a/src/acbm/matching.py
+++ b/src/acbm/matching.py
@@ -342,7 +342,7 @@ def match_remaining_individuals(
         rows_df2 = df2
         if show_progress:
             # Print the iteration number and the number of keys in the dict
-            print(
+            logger.info(
                 f"Matching remaining individuals, {i * chunk_size} out of: {len(remaining_ids)}"
             )
 

--- a/src/acbm/preprocessing.py
+++ b/src/acbm/preprocessing.py
@@ -111,47 +111,48 @@ def nts_filter_by_region(
 
     # Dictionary of the regions in the NTS and how they are coded
     # PSUGOR_B02ID but does not have values for 2021 and 2022
-    region_dict = {
-        -10.0: "DEAD",
-        -9.0: "DNA",
-        -8.0: "NA",
-        1.0: "North East",
-        2.0: "North West",
-        3.0: "Yorkshire and the Humber",
-        4.0: "East Midlands",
-        5.0: "West Midlands",
-        6.0: "East of England",
-        7.0: "London",
-        8.0: "South East",
-        9.0: "South West",
-        10.0: "Wales",
-        11.0: "Scotland",
-    }
-    # PSUStatsReg_B01ID but does not have values for 2021 and 2022
     # region_dict = {
     #     -10.0: "DEAD",
     #     -9.0: "DNA",
     #     -8.0: "NA",
-    #     1.0: "Northern, Metropolitan",
-    #     2.0: "Northern, Non-metropolitan",
-    #     3.0: "Yorkshire / Humberside, Metropolitan",
-    #     4.0: "Yorkshire / Humberside, Non-metropolitan",
-    #     5.0: "East Midlands",
-    #     6.0: "East Anglia",
-    #     7.0: "South East (excluding London Boroughs)",
-    #     8.0: "London Boroughs",
+    #     1.0: "North East",
+    #     2.0: "North West",
+    #     3.0: "Yorkshire and the Humber",
+    #     4.0: "East Midlands",
+    #     5.0: "West Midlands",
+    #     6.0: "East of England",
+    #     7.0: "London",
+    #     8.0: "South East",
     #     9.0: "South West",
-    #     10.0: "West Midlands, Metropolitan",
-    #     11.0: "West Midlands, Non-metropolitan",
-    #     12.0: "North West, Metropolitan",
-    #     13.0: "North West, Non-metropolitan",
-    #     14.0: "Wales",
-    #     15.0: "Scotland",
+    #     10.0: "Wales",
+    #     11.0: "Scotland",
     # }
 
+    # PSUStatsReg_B01ID but does not have values for 2021 and 2022
+    region_dict = {
+        -10.0: "DEAD",
+        -9.0: "DNA",
+        -8.0: "NA",
+        1.0: "Northern, Metropolitan",
+        2.0: "Northern, Non-metropolitan",
+        3.0: "Yorkshire / Humberside, Metropolitan",
+        4.0: "Yorkshire / Humberside, Non-metropolitan",
+        5.0: "East Midlands",
+        6.0: "East Anglia",
+        7.0: "South East (excluding London Boroughs)",
+        8.0: "London Boroughs",
+        9.0: "South West",
+        10.0: "West Midlands, Metropolitan",
+        11.0: "West Midlands, Non-metropolitan",
+        12.0: "North West, Metropolitan",
+        13.0: "North West, Non-metropolitan",
+        14.0: "Wales",
+        15.0: "Scotland",
+    }
+
     # In the PSU table, create a column with the region names
-    psu["region_name"] = psu["PSUGOR_B02ID"].map(region_dict)
-    # psu["region_name"] = psu["PSUStatsReg_B01ID"].map(region_dict)
+    # psu["region_name"] = psu["PSUGOR_B02ID"].map(region_dict)
+    psu["region_name"] = psu["PSUStatsReg_B01ID"].map(region_dict)
 
     # 2. Check that all values of 'years' exist in the 'SurveyYear' column of 'psu'
 

--- a/src/acbm/preprocessing.py
+++ b/src/acbm/preprocessing.py
@@ -70,11 +70,10 @@ def nts_filter_by_year(
 
     data: pandas DataFrame
         The NTS data to be filtered
-    psu: pandas DataFrame
-        The Primary Sampling Unit table in the NTS. It has the year
     years: list
         The chosen year(s)
     """
+    # return data.loc[data["SurveyYear"].isin(years)]
     # Check that all values of 'years' exist in the 'SurveyYear' column of 'psu'
 
     # Get the unique years in the 'SurveyYear' column of 'psu'
@@ -111,6 +110,7 @@ def nts_filter_by_region(
     # 1. Create a column in the PSU table with the region names
 
     # Dictionary of the regions in the NTS and how they are coded
+    # PSUGOR_B02ID but does not have values for 2021 and 2022
     region_dict = {
         -10.0: "DEAD",
         -9.0: "DNA",
@@ -127,8 +127,31 @@ def nts_filter_by_region(
         10.0: "Wales",
         11.0: "Scotland",
     }
+    # PSUStatsReg_B01ID but does not have values for 2021 and 2022
+    # region_dict = {
+    #     -10.0: "DEAD",
+    #     -9.0: "DNA",
+    #     -8.0: "NA",
+    #     1.0: "Northern, Metropolitan",
+    #     2.0: "Northern, Non-metropolitan",
+    #     3.0: "Yorkshire / Humberside, Metropolitan",
+    #     4.0: "Yorkshire / Humberside, Non-metropolitan",
+    #     5.0: "East Midlands",
+    #     6.0: "East Anglia",
+    #     7.0: "South East (excluding London Boroughs)",
+    #     8.0: "London Boroughs",
+    #     9.0: "South West",
+    #     10.0: "West Midlands, Metropolitan",
+    #     11.0: "West Midlands, Non-metropolitan",
+    #     12.0: "North West, Metropolitan",
+    #     13.0: "North West, Non-metropolitan",
+    #     14.0: "Wales",
+    #     15.0: "Scotland",
+    # }
+
     # In the PSU table, create a column with the region names
     psu["region_name"] = psu["PSUGOR_B02ID"].map(region_dict)
+    # psu["region_name"] = psu["PSUStatsReg_B01ID"].map(region_dict)
 
     # 2. Check that all values of 'years' exist in the 'SurveyYear' column of 'psu'
 

--- a/src/acbm/preprocessing.py
+++ b/src/acbm/preprocessing.py
@@ -73,7 +73,6 @@ def nts_filter_by_year(
     years: list
         The chosen year(s)
     """
-    # return data.loc[data["SurveyYear"].isin(years)]
     # Check that all values of 'years' exist in the 'SurveyYear' column of 'psu'
 
     # Get the unique years in the 'SurveyYear' column of 'psu'

--- a/src/acbm/utils.py
+++ b/src/acbm/utils.py
@@ -59,6 +59,8 @@ def households_with_common_travel_days(
         .apply(
             lambda common_days: [day for day in common_days if day in days]
             if common_days is not None
+            and common_days != {pd.NA}
+            and common_days != {np.nan}
             else []
         )
         .apply(lambda common_days: common_days if common_days else pd.NA)

--- a/src/acbm/utils.py
+++ b/src/acbm/utils.py
@@ -47,7 +47,6 @@ def households_with_common_travel_days(
 ) -> list[int]:
     return (
         pl.DataFrame(nts_trips)
-        .lazy()
         # group_by household and individual
         .group_by([hid, pid])
         # get unique travel days
@@ -71,7 +70,6 @@ def households_with_common_travel_days(
         .filter(pl.col("day_count").eq(pl.col("count")))
         # filter for days in given set of days
         .filter(pl.col("TravDay").is_in(days))
-        .collect()
         # return list of unique household ids
         .get_column(hid)
         .unique()

--- a/src/acbm/utils.py
+++ b/src/acbm/utils.py
@@ -47,6 +47,7 @@ def households_with_common_travel_days(
 ) -> list[int]:
     return (
         pl.DataFrame(nts_trips)
+        .lazy()
         # group_by household and individual
         .group_by([hid, pid])
         # get unique travel days
@@ -70,9 +71,11 @@ def households_with_common_travel_days(
         .filter(pl.col("day_count").eq(pl.col("count")))
         # filter for days in given set of days
         .filter(pl.col("TravDay").is_in(days))
+        .collect()
         # return list of unique household ids
         .get_column(hid)
         .unique()
+        .sort()
         .to_list()
     )
 

--- a/src/acbm/utils.py
+++ b/src/acbm/utils.py
@@ -42,14 +42,14 @@ def get_travel_times(config: Config, use_estimates: bool = False) -> pd.DataFram
 
 
 def households_with_common_travel_days(
-    nts_trips: pd.DataFrame, days: list[int]
+    nts_trips: pd.DataFrame, days: list[int], hid="HouseholdID", pid="IndividualID"
 ) -> list[int]:
     return (
-        nts_trips.groupby(["HouseholdID", "IndividualID"])["TravDay"]
+        nts_trips.groupby([hid, pid])["TravDay"]
         .apply(list)
         .map(set)
         .to_frame()
-        .groupby(["HouseholdID"])["TravDay"]
+        .groupby([hid])["TravDay"]
         .apply(
             lambda sets_of_days: set.intersection(*sets_of_days)
             if set.intersection(*sets_of_days)
@@ -65,6 +65,6 @@ def households_with_common_travel_days(
         )
         .apply(lambda common_days: common_days if common_days else pd.NA)
         .dropna()
-        .reset_index()["HouseholdID"]
+        .reset_index()[hid]
         .to_list()
     )

--- a/src/acbm/validating/utils.py
+++ b/src/acbm/validating/utils.py
@@ -7,8 +7,7 @@ from acbm.assigning.utils import _adjust_distance
 
 def process_sequences(
     df: pd.DataFrame,
-    pid_col: str,
-    seq_col: str,
+    groupby_cols: list[str],
     origin_activity_col: str,
     destination_activity_col: str,
     suffix: str,
@@ -44,13 +43,13 @@ def process_sequences(
         home - school - home                    3
         home - work - home                     20
     """
-    # Step 1: Sort the DataFrame by 'pid' and 'seq'
-    sorted_df = df.sort_values(by=[pid_col, seq_col])
+    # Step 1: Sort the DataFrame by `groupby_cols` and 'seq'
+    sorted_df = df.sort_values(by=[*groupby_cols, "seq"])
 
     # Step 2: Group by 'pid' and concatenate 'origin activity' values followed by the
     # last 'destination activity' value
     activity_sequence_df = (
-        sorted_df.groupby(pid_col)
+        sorted_df.groupby(groupby_cols)
         .apply(
             lambda x: " - ".join(
                 [*x[origin_activity_col], x[destination_activity_col].iloc[-1]]
@@ -60,7 +59,10 @@ def process_sequences(
     )
 
     # Rename the columns for clarity
-    activity_sequence_df.columns = [pid_col, "activity_sequence"]
+    activity_sequence_df.columns = [
+        *activity_sequence_df.columns[:-1],
+        "activity_sequence",
+    ]
 
     # Step 3: Group by the resulting 'activity_sequence' column and count the number of
     # values in each group

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,4 +11,4 @@ def config():
 
 
 def test_id(config):
-    assert config.id == "0ebb8c3ee7"
+    assert config.id == "464741c848"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,4 +11,4 @@ def config():
 
 
 def test_id(config):
-    assert config.id == "464741c848"
+    assert config.id == "5709d35b6f"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,4 +11,4 @@ def config():
 
 
 def test_id(config):
-    assert config.id == "5709d35b6f"
+    assert config.id == "21e42c9d68"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,4 +11,4 @@ def config():
 
 
 def test_id(config):
-    assert config.id == "19274f64ff"
+    assert config.id == "d085ed50b9"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,4 +11,4 @@ def config():
 
 
 def test_id(config):
-    assert config.id == "21e42c9d68"
+    assert config.id == "19274f64ff"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,9 +8,26 @@ from acbm.utils import households_with_common_travel_days
 def nts_trips():
     return pd.DataFrame.from_dict(
         {
-            "IndividualID": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-            "HouseholdID": [1, 1, 1, 2, 2, 2, 3, 3, 3, 3],
-            "TravDay": [1, 1, 1, 2, 3, 2, 3, 3, 3, 3],
+            "IndividualID": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            "HouseholdID": [1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5],
+            "TravDay": [
+                1,
+                1,
+                1,
+                2,
+                3,
+                2,
+                3,
+                3,
+                3,
+                3,
+                pd.NA,
+                pd.NA,
+                pd.NA,
+                pd.NA,
+                pd.NA,
+                4,
+            ],
         }
     )
 
@@ -19,3 +36,4 @@ def test_households_with_common_travel_days(nts_trips):
     assert households_with_common_travel_days(nts_trips, [1]) == [1]
     assert households_with_common_travel_days(nts_trips, [1, 2]) == [1]
     assert households_with_common_travel_days(nts_trips, [1, 3]) == [1, 3]
+    assert households_with_common_travel_days(nts_trips, [1, 3, 4]) == [1, 3]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
 import pandas as pd
+import polars as pl
 import pytest
 
+from acbm.assigning.utils import get_chosen_day
+from acbm.config import load_config
 from acbm.utils import (
     households_with_common_travel_days,
     households_with_travel_days_in_nts_weeks,
@@ -8,56 +11,46 @@ from acbm.utils import (
 
 
 @pytest.fixture
+def config():
+    return load_config("config/base.toml")
+
+
+@pytest.fixture
 def nts_trips():
-    return pd.DataFrame.from_dict(
-        {
-            "IndividualID": [
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-            ],
-            "HouseholdID": [1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 7, 7],
-            "TravDay": [
-                1,
-                1,
-                1,
-                2,
-                3,
-                2,
-                3,
-                3,
-                3,
-                3,
-                pd.NA,
-                pd.NA,
-                pd.NA,
-                pd.NA,
-                pd.NA,
-                4,
-                4,
-                5,
-                5,
-                pd.NA,
-            ],
-        }
+    return pd.DataFrame(
+        [
+            [1, 1, 1],
+            [2, 1, 1],
+            [3, 1, 1],
+            [4, 2, 2],
+            [4, 2, 4],
+            [5, 2, 3],
+            [6, 3, 3],
+            [7, 3, 3],
+            [8, 3, 3],
+            [9, 3, 3],
+            [10, 4, pd.NA],
+            [11, 4, pd.NA],
+            [12, 4, pd.NA],
+            [13, 5, pd.NA],
+            [14, 5, pd.NA],
+            [15, 5, 4],
+            [16, 5, 4],
+            [17, 6, 5],
+            [18, 6, 5],
+            [19, 6, pd.NA],
+            [19, 6, 4],
+        ],
+        columns=["IndividualID", "HouseholdID", "TravDay"],
     )
+
+
+@pytest.fixture
+def nts_trips_with_aliases(nts_trips):
+    df = nts_trips
+    df["id"] = df["IndividualID"]
+    df["household"] = df["HouseholdID"]
+    return df
 
 
 def test_households_with_common_travel_days(nts_trips):
@@ -71,9 +64,34 @@ def test_households_with_travel_days_in_nts_weeks(nts_trips):
     assert households_with_travel_days_in_nts_weeks(nts_trips, [1]) == [1]
     assert households_with_travel_days_in_nts_weeks(nts_trips, [1, 2]) == [1]
     assert households_with_travel_days_in_nts_weeks(nts_trips, [1, 3]) == [1, 3]
-    assert households_with_travel_days_in_nts_weeks(nts_trips, [1, 3, 4]) == [1, 3]
+    assert households_with_travel_days_in_nts_weeks(nts_trips, [1, 3, 4]) == [1, 2, 3]
     assert households_with_travel_days_in_nts_weeks(nts_trips, [1, 3, 4, 5]) == [
         1,
+        2,
         3,
         6,
     ]
+
+
+def test_get_chosen_day_with_common_travel_day(nts_trips_with_aliases):
+    pl.set_random_seed(0)
+    hids = households_with_common_travel_days(nts_trips_with_aliases, [1, 3, 4])
+    nts_trips_with_aliases = nts_trips_with_aliases[
+        nts_trips_with_aliases["household"].isin(hids)
+    ]
+    df = get_chosen_day(nts_trips_with_aliases, True)
+    print(df)
+    assert df.to_numpy().prod(1).sum() == 96
+
+
+def test_get_chosen_day_with_travel_days_in_nts_weeks(nts_trips_with_aliases):
+    pl.set_random_seed(0)
+    hids = households_with_travel_days_in_nts_weeks(
+        nts_trips_with_aliases, [1, 3, 4, 5]
+    )
+    nts_trips_with_aliases = nts_trips_with_aliases[
+        nts_trips_with_aliases["household"].isin(hids)
+    ]
+    df = get_chosen_day(nts_trips_with_aliases, False)
+    print(df)
+    assert df.to_numpy().prod(1).sum() == 370

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import polars as pl
 import pytest
 
 from acbm.assigning.utils import get_chosen_day
@@ -74,10 +73,11 @@ def test_households_with_travel_days_in_nts_weeks(nts_trips):
 
 
 def test_get_chosen_day_with_common_travel_day(nts_trips_with_aliases):
-    pl.set_random_seed(0)
-    hids = households_with_common_travel_days(nts_trips_with_aliases, [1, 3, 4])
+    days = [1, 3, 4]
+    hids = households_with_common_travel_days(nts_trips_with_aliases, days)
     nts_trips_with_aliases = nts_trips_with_aliases[
         nts_trips_with_aliases["household"].isin(hids)
+        & nts_trips_with_aliases["TravDay"].isin(days)
     ]
     df = get_chosen_day(nts_trips_with_aliases, True)
     print(df)
@@ -85,13 +85,12 @@ def test_get_chosen_day_with_common_travel_day(nts_trips_with_aliases):
 
 
 def test_get_chosen_day_with_travel_days_in_nts_weeks(nts_trips_with_aliases):
-    pl.set_random_seed(0)
-    hids = households_with_travel_days_in_nts_weeks(
-        nts_trips_with_aliases, [1, 3, 4, 5]
-    )
+    days = [1, 3, 4, 5]
+    hids = households_with_travel_days_in_nts_weeks(nts_trips_with_aliases, days)
     nts_trips_with_aliases = nts_trips_with_aliases[
         nts_trips_with_aliases["household"].isin(hids)
+        & nts_trips_with_aliases["TravDay"].isin(days)
     ]
     df = get_chosen_day(nts_trips_with_aliases, False)
     print(df)
-    assert df.to_numpy().prod(1).sum() == 370
+    assert df.to_numpy().prod(1).sum() == 378

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,39 @@
 import pandas as pd
 import pytest
 
-from acbm.utils import households_with_common_travel_days
+from acbm.utils import (
+    households_with_common_travel_days,
+    households_with_travel_days_in_nts_weeks,
+)
 
 
 @pytest.fixture
 def nts_trips():
     return pd.DataFrame.from_dict(
         {
-            "IndividualID": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-            "HouseholdID": [1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5],
+            "IndividualID": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+            ],
+            "HouseholdID": [1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 7, 7],
             "TravDay": [
                 1,
                 1,
@@ -27,6 +51,10 @@ def nts_trips():
                 pd.NA,
                 pd.NA,
                 4,
+                4,
+                5,
+                5,
+                pd.NA,
             ],
         }
     )
@@ -37,3 +65,15 @@ def test_households_with_common_travel_days(nts_trips):
     assert households_with_common_travel_days(nts_trips, [1, 2]) == [1]
     assert households_with_common_travel_days(nts_trips, [1, 3]) == [1, 3]
     assert households_with_common_travel_days(nts_trips, [1, 3, 4]) == [1, 3]
+
+
+def test_households_with_travel_days_in_nts_weeks(nts_trips):
+    assert households_with_travel_days_in_nts_weeks(nts_trips, [1]) == [1]
+    assert households_with_travel_days_in_nts_weeks(nts_trips, [1, 2]) == [1]
+    assert households_with_travel_days_in_nts_weeks(nts_trips, [1, 3]) == [1, 3]
+    assert households_with_travel_days_in_nts_weeks(nts_trips, [1, 3, 4]) == [1, 3]
+    assert households_with_travel_days_in_nts_weeks(nts_trips, [1, 3, 4, 5]) == [
+        1,
+        3,
+        6,
+    ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import pytest
+
+from acbm.utils import households_with_common_travel_days
+
+
+@pytest.fixture
+def nts_trips():
+    return pd.DataFrame.from_dict(
+        {
+            "IndividualID": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "HouseholdID": [1, 1, 1, 2, 2, 2, 3, 3, 3, 3],
+            "TravDay": [1, 1, 1, 2, 3, 2, 3, 3, 3, 3],
+        }
+    )
+
+
+def test_households_with_common_travel_days(nts_trips):
+    assert households_with_common_travel_days(nts_trips, [1]) == [1]
+    assert households_with_common_travel_days(nts_trips, [1, 2]) == [1]
+    assert households_with_common_travel_days(nts_trips, [1, 3]) == [1, 3]


### PR DESCRIPTION
Closes #86.

This PR continues from closed #82 rebased on main with new branch name.

This PR:
- Adds configurable common day of travel for households and revise the filtering of NTS trips to before matching to increase matches with non-missing trips. When config is not common travel day, then any day is chosen from the set of configured `nts_days_of_week`
- Serializes a `chosen_day` randomly picked during feasible zone assignment
- Revises the subset of commuting flows to exclude WFH as it seems NTS would not record a trip
- Relatedly, the PR adds "scaling" of flows that can be configured currently using the `part_time_work_prob` parameter (see [below](https://github.com/Urban-Analytics-Technology-Platform/acbm/pull/90#discussion_r1941583750)). The related [census question 49](https://www.ons.gov.uk/file?uri=/census/censustransformationprogramme/questiondevelopment/census2021paperquestionnaires/englishindividual.pdf) ("Where do you mainly work?") suggests that on a randomly chosen work day an individual would not necessarily be commuting. A float for scaling can be applied to the flows applicable if `use_percentages=False` (see https://github.com/Urban-Analytics-Technology-Platform/acbm/issues/86#issue-2795761126 for additional discussion)
- Adds initial approach for matching for unmatched individuals after household matching
- Revises the variable used for region to `"PSUStatsReg_B01ID"` as this is included for 2021 and 2022
- Adds tests

Remaining tasks:
- [x] Update the README file strucuture
- [x] Explore the issue around the increased number of `h - w -h` chains in the validation script