### PR TITLE
Add variables for remaining individual matching

### DIFF
--- a/scripts/2_match_households_and_individuals.py
+++ b/scripts/2_match_households_and_individuals.py
@@ -7,7 +7,12 @@ import pandas as pd
 from acbm.assigning.utils import cols_for_assignment_all
 from acbm.cli import acbm_cli
 from acbm.config import load_and_setup_config
-from acbm.matching import MatcherExact, match_individuals, match_remaining_individuals
+from acbm.matching import (
+    MatcherExact,
+    match_individuals,
+    match_remaining_individuals,
+    matched_ids_from_right_for_left,
+)
 from acbm.preprocessing import (
     count_per_group,
     nts_filter_by_region,
@@ -1030,12 +1035,10 @@ def main(config_file):
         ) as f:
             matches_ind = pkl.load(f)
 
-    # Add matches_ind values to spc_edited using map
-    spc_edited["nts_ind_id"] = spc_edited.index.map(matches_ind)
-
-    # add the nts_individuals.IndividualID to spc_edit. The current nts_ind_id is the row index of nts_individuals
-    spc_edited["nts_ind_id"] = spc_edited["nts_ind_id"].map(
-        nts_individuals["IndividualID"]
+    # Add matches_ind values to spc_edited using map and add the nts_individuals.IndividualID to spc_edit.
+    # The current nts_ind_id is the row index of nts_individuals
+    spc_edited["nts_ind_id"] = matched_ids_from_right_for_left(
+        spc_edited, nts_individuals, matches_ind, right_id="IndividualID"
     )
 
     logger.info("Statistical matching: Matching complete")

--- a/scripts/2_match_households_and_individuals.py
+++ b/scripts/2_match_households_and_individuals.py
@@ -1035,8 +1035,7 @@ def main(config_file):
         ) as f:
             matches_ind = pkl.load(f)
 
-    # Add matches_ind values to spc_edited using map and add the nts_individuals.IndividualID to spc_edit.
-    # The current nts_ind_id is the row index of nts_individuals
+    # Add matched `IndividualID` from `nts_individuals` to to `spc_edited`
     spc_edited["nts_ind_id"] = matched_ids_from_right_for_left(
         spc_edited, nts_individuals, matches_ind, right_id="IndividualID"
     )

--- a/src/acbm/matching.py
+++ b/src/acbm/matching.py
@@ -172,7 +172,12 @@ class MatcherExact:
 # propensity score matching - (for individual level)
 
 
-def match_psm(df1: pd.DataFrame, df2: pd.DataFrame, matching_columns: list) -> dict:
+def match_psm(
+    df1: pd.DataFrame,
+    df2: pd.DataFrame,
+    matching_columns: list,
+    starts_with: bool = False,
+) -> dict:
     """
     Use the Propensity Score Matching (PSM) method to match the rows in two DataFrames
     The distances between columns is calculated using the NearestNeighbors algorithm
@@ -194,6 +199,17 @@ def match_psm(df1: pd.DataFrame, df2: pd.DataFrame, matching_columns: list) -> d
 
     # Initialize an empty dict to store the matches
     matches = {}
+    if starts_with:
+        matching_columns_df1 = sorted(
+            col for start in matching_columns for col in df1 if col.startswith(start)
+        )
+        matching_columns_df2 = sorted(
+            col for start in matching_columns for col in df2 if col.startswith(start)
+        )
+        if matching_columns_df1 != matching_columns_df2:
+            err_msg = f"'matching_columns_df1' ({matching_columns_df1}) do not equal 'matching_columns_df2' ({matching_columns_df2})"
+            raise ValueError(err_msg)
+        matching_columns = matching_columns_df1
 
     # Matching without replacement
     while not df1.empty:
@@ -347,7 +363,7 @@ def match_remaining_individuals(
             )
 
         # apply the matching
-        match = match_psm(rows_df1, rows_df2, matching_columns)
+        match = match_psm(rows_df1, rows_df2, matching_columns, starts_with=True)
 
         # append the results to the main dict
         matches.update(match)

--- a/src/acbm/matching.py
+++ b/src/acbm/matching.py
@@ -369,3 +369,10 @@ def match_remaining_individuals(
         matches.update(match)
 
     return matches
+
+
+def matched_ids_from_right_for_left(
+    left, right, matches_dict, right_id: str = "id"
+) -> pd.DataFrame:
+    """Gets the matched rows from right for left"""
+    return left.index.map(matches_dict).map(right[right_id])

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -137,12 +137,16 @@ def get_test_dfs_and_mapping(mapping):
 
 @pytest.fixture
 def ind_hh():
+    """Returns a new population where the order of individuals within households is
+    shuffled to test matching of individuals grouped by household"""
     mapping_ind_within_hh = [0, 3, 1, 2, 4, 6, 5, 9, 8, 7]
     return get_test_dfs_and_mapping(mapping_ind_within_hh)
 
 
 @pytest.fixture
 def ind_rem():
+    """Returns a new population where the order of individuals is shuffled to test
+    matching of remaining individuals"""
     mapping_ind = [1, 7, 9, 3, 0, 5, 2, 6, 8, 4]
     return get_test_dfs_and_mapping(mapping_ind)
 


### PR DESCRIPTION
Closes #85.

This PR:
- Includes additional variables for remaining individual matching
- Includes functionality in `match_psm` to select matching columns that start with the given column names

Remaining tasks:
- [x] Add tests