### PR TITLE
osmox edits

### DIFF
--- a/osmox/config_osmox.json
+++ b/osmox/config_osmox.json
@@ -42,7 +42,7 @@
 
 	"object_features": ["units", "levels", "area", "floor_area"],
 
-	"distance_to_nearest": ["transit", "shop", "medical"],
+	"distance_to_nearest": ["medical"],
 
 	"default_tags": [["building", "residential"]],
 

--- a/scripts/0.1_run_osmox.py
+++ b/scripts/0.1_run_osmox.py
@@ -27,7 +27,9 @@ def main(config_file):
             for chunk in response.iter_content(chunk_size=8192):
                 file.write(chunk)
         logger.info(f"Region ({config.region}) successfully downloaded to: {fp}")
-    logger.info("Running osmox")
+    # Use the CRS value from the config
+    crs_value = f"epsg:{config.output_crs}"
+    logger.info(f"Running osmox with output crs: {crs_value}")
     subprocess.run(
         [
             "osmox",
@@ -43,7 +45,7 @@ def main(config_file):
             # However, distances from osmox are currently not used in the pipeline so any CRS will work.
             # In general, the CRS is transformed in the pipeline when this data is used.
             # See: https://github.com/arup-group/osmox/blob/82602d411374ebc9fd33443f8f7c9816b63715ec/docs/osmox_run.md#L35-L38
-            "epsg:27700",
+            crs_value,
             "-l",
         ],
         check=False,

--- a/scripts/5_acbm_to_matsim_xml.py
+++ b/scripts/5_acbm_to_matsim_xml.py
@@ -162,6 +162,7 @@ def main(config_file):
     population.individuals.rename(
         columns={"salary_yearly": "indIncomeSPC"}, inplace=True
     )
+
     # replace NaN with 0
     population.individuals["indIncomeSPC"] = population.individuals[
         "indIncomeSPC"

--- a/src/acbm/config.py
+++ b/src/acbm/config.py
@@ -11,6 +11,7 @@ import jcs
 import numpy as np
 import tomlkit
 from pydantic import BaseModel, Field, field_serializer, field_validator
+from pyproj import CRS
 
 import acbm
 from acbm.logger_config import create_logger
@@ -30,6 +31,17 @@ class Parameters(BaseModel):
     output_crs: int
     tolerance_work: float | None = None
     tolerance_edu: float | None = None
+
+    @field_validator("output_crs")
+    def validate_output_crs(output_crs: int) -> int:
+        if not CRS(output_crs).is_projected:
+            msg = (
+                f"Output CRS is expected to be projected. Output CRS was {output_crs}. "
+                "We recommend 27700 for a metric CRS for England "
+                "(the currently supported region)."
+            )
+            raise ValueError(msg)
+        return output_crs
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### CRS Handling Improvements:

* [`scripts/0.1_run_osmox.py`]: Updated the script to use the CRS value from the configuration file, see #87 

### Configuration Updates:

* [`osmox/config_osmox.json`]: Removed the `transit` and `shop` features from the `distance_to_nearest` list,. These take a long time and we don't use them anyway. I kept medical so that `distance_to_nearest` is kept as a placeholder in the config that can be extended, but we don't actually need it