### PR TITLE
Remove PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # acbm
 
 [![Actions Status][actions-badge]][actions-link]
-[![PyPI version][pypi-version]][pypi-link]
-[![PyPI platforms][pypi-platforms]][pypi-link]
 
 A package to create activity-based models (for transport demand modelling)
 
@@ -193,7 +191,7 @@ Distributed under the terms of the [Apache license](LICENSE).
 <!-- prettier-ignore-start -->
 [actions-badge]:            https://github.com/alan-turing-institute/acbm/workflows/CI/badge.svg
 [actions-link]:             https://github.com/alan-turing-institute/acbm/actions
-[pypi-link]:                https://pypi.org/project/acbm/
-[pypi-platforms]:           https://img.shields.io/pypi/pyversions/acbm
-[pypi-version]:             https://img.shields.io/pypi/v/acbm
+<!-- [pypi-link]:                https://pypi.org/project/acbm/ -->
+<!-- [pypi-platforms]:           https://img.shields.io/pypi/pyversions/acbm -->
+<!-- [pypi-version]:             https://img.shields.io/pypi/v/acbm -->
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
This PR removes PyPI badges as these are not currently required.