### PR TITLE
fix: OverflowError matplotlib

### DIFF
--- a/src/acbm/assigning/plots.py
+++ b/src/acbm/assigning/plots.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 import geopandas as gpd
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -12,6 +13,9 @@ from matplotlib import patches as mpatches
 from shapely.geometry import LineString
 
 from acbm.assigning.utils import _adjust_distance
+
+# Increase the chunksize to avoid OverflowError
+mpl.rcParams["agg.path.chunksize"] = 10000
 
 
 def plot_workzone_assignment_line(


### PR DESCRIPTION
This should fix the matplotlib OverflowError reported by @sgreenbury when running for London

```
OverflowError: Exceeded cell block limit in Agg.  Please set the value of rcParams['agg.path.chunksize'], (currently 0) to be greater than 100 or increase the path simplification threshold(rcParams['path.simplify_threshold'] = 0.111111111111 by default and path.simplify_threshold = 0.111111111111 on the input).
Error: Command '['python', 'scripts/3.3_assign_facility_all.py', '--config-file', 'config/2025-03-25_greater-london_msoa_new_regions_01_2020.toml']' returned non-zero exit status 1.
```